### PR TITLE
Add FluxDiscardOnCancel draft

### DIFF
--- a/src/main/java/io/r2dbc/mssql/LoginFlow.java
+++ b/src/main/java/io/r2dbc/mssql/LoginFlow.java
@@ -71,7 +71,7 @@ final class LoginFlow {
 
         Prelogin request = builder.build();
 
-        return client.exchange(requestProcessor.startWith(request)) //
+        return client.exchange(requestProcessor.startWith(request), DoneToken::isDone) //
             .filter(or(Prelogin.class::isInstance, SslState.class::isInstance, DoneToken.class::isInstance, ErrorToken.class::isInstance)) //
             .handle((message, sink) -> {
 

--- a/src/main/java/io/r2dbc/mssql/MssqlConnection.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnection.java
@@ -20,6 +20,7 @@ import io.r2dbc.mssql.client.Client;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.client.TransactionStatus;
 import io.r2dbc.mssql.util.Assert;
+import io.r2dbc.mssql.util.Operators;
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
@@ -230,7 +231,10 @@ public final class MssqlConnection implements Connection {
     private Mono<Void> exchange(String sql) {
 
         ExceptionFactory factory = ExceptionFactory.withSql(sql);
-        return QueryMessageFlow.exchange(this.client, sql).handle(factory::handleErrorResponse).then();
+        return QueryMessageFlow.exchange(this.client, sql)
+            .handle(factory::handleErrorResponse)
+            .transform(Operators::discardOnCancel)
+            .then();
     }
 
     Client getClient() {

--- a/src/main/java/io/r2dbc/mssql/ParametrizedMssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/ParametrizedMssqlStatement.java
@@ -129,7 +129,7 @@ final class ParametrizedMssqlStatement extends MssqlStatementSupport implements 
             Iterator<Binding> iterator = this.bindings.bindings.iterator();
             EmitterProcessor<Binding> bindingEmitter = EmitterProcessor.create(true);
             return bindingEmitter.startWith(iterator.next())
-                .flatMap(it -> {
+                .concatMap(it -> {
 
                     Flux<Message> exchange = exchange(effectiveFetchSize, useGeneratedKeysClause, sql, it);
 

--- a/src/main/java/io/r2dbc/mssql/SimpleMssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/SimpleMssqlStatement.java
@@ -24,6 +24,7 @@ import io.r2dbc.mssql.message.token.AbstractDoneToken;
 import io.r2dbc.mssql.message.token.DoneInProcToken;
 import io.r2dbc.mssql.message.token.SqlBatch;
 import io.r2dbc.mssql.util.Assert;
+import io.r2dbc.mssql.util.Operators;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +130,7 @@ final class SimpleMssqlStatement extends MssqlStatementSupport implements MssqlS
                     logger.debug(this.context.getMessage("Start direct exchange for {}"), sql);
                 }
 
-                exchange = QueryMessageFlow.exchange(this.client, sql);
+                exchange = QueryMessageFlow.exchange(this.client, sql).transform(Operators::discardOnCancel);
 
                 return createResultStream(useGeneratedKeysClause, exchange, AbstractDoneToken.class::isInstance);
             }

--- a/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
@@ -49,19 +49,24 @@ import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoSink;
 import reactor.core.publisher.SynchronousSink;
 import reactor.netty.Connection;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.TcpClient;
+import reactor.util.concurrent.Queues;
 import reactor.util.context.Context;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * An implementation of a TDS client based on the Reactor Netty project.
@@ -102,23 +107,29 @@ public final class ReactorNettyClient implements Client {
 
     private final EmitterProcessor<Message> responseProcessor = EmitterProcessor.create(false);
 
+    private final TransactionListener transactionListener = new TransactionListener();
+
+    private final CollationListener collationListener = new CollationListener();
+
+    private final RequestQueue requestQueue;
+
+    // May change during initialization. Values remain the same after connection initialization.
+
     private ConnectionState state = ConnectionState.PRELOGIN;
 
     private MessageDecoder decodeFunction = ConnectionState.PRELOGIN.decoder(this);
 
     private boolean encryptionSupported = false;
 
+    private Optional<String> databaseVersion = Optional.empty();
+
+    // May change during driver interaction, may be read on other threads.
+
     private volatile TransactionDescriptor transactionDescriptor = TransactionDescriptor.empty();
 
     private volatile TransactionStatus transactionStatus = TransactionStatus.AUTO_COMMIT;
 
     private volatile Optional<Collation> databaseCollation = Optional.empty();
-
-    private volatile Optional<String> databaseVersion = Optional.empty();
-
-    private TransactionListener transactionListener = new TransactionListener();
-
-    private CollationListener collationListener = new CollationListener();
 
     /**
      * Creates a new frame processor connected to a given TCP connection.
@@ -139,8 +150,8 @@ public final class ReactorNettyClient implements Client {
 
             try {
                 tdsEncoder.onEnvironmentChange(event);
-                transactionListener.onEnvironmentChange(event);
-                collationListener.onEnvironmentChange(event);
+                this.transactionListener.onEnvironmentChange(event);
+                this.collationListener.onEnvironmentChange(event);
             } catch (Exception e) {
                 logger.warn(this.context.getMessage("Failed onEnvironmentChange() in {}"), "", e);
             }
@@ -149,6 +160,7 @@ public final class ReactorNettyClient implements Client {
         this.byteBufAllocator = connection.outbound().alloc();
         this.connection = connection;
         this.tdsEncoder = tdsEncoder;
+        this.requestQueue = new RequestQueue(this.context);
 
         connection.addHandlerFirst(new ChannelInboundHandlerAdapter() {
 
@@ -193,12 +205,12 @@ public final class ReactorNettyClient implements Client {
 
             @Override
             public Context currentContext() {
-                return requestProcessor.currentContext();
+                return ReactorNettyClient.this.requestProcessor.currentContext();
             }
 
             @Override
             public void error(Throwable e) {
-                responseProcessor.onError(e);
+                ReactorNettyClient.this.responseProcessor.onError(e);
             }
 
             @Override
@@ -211,14 +223,14 @@ public final class ReactorNettyClient implements Client {
                 handleStateChange.accept(message);
 
                 if (message.getClass() == EnvChangeToken.class) {
-                    handleEnvChange.accept((EnvChangeToken) message);
+                    ReactorNettyClient.this.handleEnvChange.accept((EnvChangeToken) message);
                 }
 
                 if (message.getClass() == FeatureExtAckToken.class) {
-                    featureAckChange.accept((FeatureExtAckToken) message);
+                    ReactorNettyClient.this.featureAckChange.accept((FeatureExtAckToken) message);
                 }
 
-                responseProcessor.onNext(message);
+                ReactorNettyClient.this.responseProcessor.onNext(message);
             }
         };
 
@@ -249,12 +261,12 @@ public final class ReactorNettyClient implements Client {
 
             @Override
             public Context currentContext() {
-                return responseProcessor.currentContext();
+                return ReactorNettyClient.this.responseProcessor.currentContext();
             }
 
             @Override
             public void onSubscribe(Subscription s) {
-                responseProcessor.onSubscribe(s);
+                ReactorNettyClient.this.responseProcessor.onSubscribe(s);
             }
 
             @Override
@@ -264,12 +276,12 @@ public final class ReactorNettyClient implements Client {
 
             @Override
             public void onError(Throwable t) {
-                responseProcessor.onError(t);
+                ReactorNettyClient.this.responseProcessor.onError(t);
             }
 
             @Override
             public void onComplete() {
-                responseProcessor.onComplete();
+                ReactorNettyClient.this.responseProcessor.onComplete();
             }
         });
 
@@ -298,15 +310,15 @@ public final class ReactorNettyClient implements Client {
     }
 
     private void onInfoToken(Message message) {
-        logger.debug(context.getMessage("Response: {}"), message);
+        logger.debug(this.context.getMessage("Response: {}"), message);
 
         if (message instanceof AbstractInfoToken) {
             AbstractInfoToken token = (AbstractInfoToken) message;
             if (token.getClassification() == AbstractInfoToken.Classification.INFORMATIONAL) {
-                logger.debug(context.getMessage("Info: Code [{}] Severity [{}]: {}"), token.getNumber(), token.getClassification(),
+                logger.debug(this.context.getMessage("Info: Code [{}] Severity [{}]: {}"), token.getNumber(), token.getClassification(),
                     token.getMessage());
             } else {
-                logger.debug(context.getMessage("Warning: Code [{}] Severity [{}]: {}"), token.getNumber(), token.getClassification(),
+                logger.debug(this.context.getMessage("Warning: Code [{}] Severity [{}]: {}"), token.getNumber(), token.getClassification(),
                     token.getMessage());
             }
         }
@@ -441,45 +453,6 @@ public final class ReactorNettyClient implements Client {
     }
 
     @Override
-    public Flux<Message> exchange(ClientMessage request) {
-
-        Assert.requireNonNull(request, "Requests must not be null");
-
-        if (DEBUG_ENABLED) {
-            logger.debug(String.format(this.context.getMessage("exchange(%s)"), request));
-        }
-
-        /*if (this.isClosed.get()) {
-            return Flux.error(new IllegalStateException("Cannot exchange messages because the connection is closed"));
-        } */
-
-        return this.responseProcessor
-            .doOnSubscribe(s -> this.requests.next(request));
-    }
-
-    @Override
-    public Flux<Message> exchange(Publisher<? extends ClientMessage> requests) {
-
-        Assert.requireNonNull(requests, "Requests must not be null");
-
-        if (DEBUG_ENABLED) {
-            logger.debug(this.context.getMessage("exchange()"));
-        }
-
-        return Flux.defer(() -> {
-
-            logger.debug(this.context.getMessage("exchange(subscribed)"));
-
-            if (this.isClosed.get()) {
-                return Flux.error(new IllegalStateException("Cannot exchange messages because the connection is closed"));
-            }
-
-            return this.responseProcessor
-                .doOnSubscribe(s -> Flux.from(requests).subscribe(this.requests::next, this.requests::error));
-        });
-    }
-
-    @Override
     public ByteBufAllocator getByteBufAllocator() {
         return this.byteBufAllocator;
     }
@@ -514,26 +487,166 @@ public final class ReactorNettyClient implements Client {
         return this.encryptionSupported;
     }
 
+    @Override
+    public Flux<Message> exchange(Publisher<? extends ClientMessage> requests, Predicate<Message> isLastResponseFrame) {
 
-    @SuppressWarnings("unchecked")
-    private static <T extends Message> BiConsumer<Message, SynchronousSink<Message>> handleMessage(Class<T> type,
-                                                                                                   BiConsumer<T, SynchronousSink<Message>> consumer) {
-        return (message, sink) -> {
-            if (type.isInstance(message)) {
-                consumer.accept((T) message, sink);
-            } else {
-                sink.next(message);
+        Assert.requireNonNull(requests, "Requests must not be null");
+
+        if (DEBUG_ENABLED) {
+            logger.debug(this.context.getMessage("exchange()"));
+        }
+
+        ExchangeRequest exchangeRequest = new ExchangeRequest();
+
+        Flux<Message> handle = Mono.<Flux<Message>>create(sink -> {
+
+            if (DEBUG_ENABLED) {
+                logger.debug(this.context.getMessage("exchange(subscribed)"));
             }
-        };
+
+            if (this.isClosed.get()) {
+                sink.error(new IllegalStateException("Cannot exchange messages because the connection is closed"));
+                return;
+            }
+
+            Flux<Message> requestMessages = this.responseProcessor
+                .doOnSubscribe(s -> Flux.from(requests).subscribe(this.requests::next, this.requests::error));
+
+            try {
+                exchangeRequest.submit(this.requestQueue, sink, requestMessages);
+            } catch (Exception e) {
+                sink.error(e);
+            }
+
+        }).flatMapMany(Function.identity()).handle((message, sink) -> {
+
+            sink.next(message);
+
+            if (isLastResponseFrame.test(message)) {
+                exchangeRequest.complete();
+                sink.complete();
+            }
+        });
+
+        return handle.doAfterTerminate(this.requestQueue).doOnCancel(() -> {
+
+            if (!exchangeRequest.isComplete()) {
+                logger.error("Exchange cancelled while exchange is active. This is likely a bug leading to unpredictable outcome.");
+            }
+        });
     }
 
-    @SuppressWarnings("unchecked")
-    private static <T extends Message> Consumer<Message> handleExact(Class<T> type, Consumer<T> consumer) {
-        return (message) -> {
-            if (type == message.getClass()) {
-                consumer.accept((T) message);
+    /**
+     * Request queue to collect incoming exchange requests.
+     * <p>Submission conditionally queues requests if an ongoing exchange was active by the time of subscription.
+     * Drains queued commands on exchange completion if there are queued commands or disable active flag.
+     */
+    static class RequestQueue implements Runnable {
+
+        private final Queue<Runnable> requestQueue = Queues.<Runnable>small().get();
+
+        private final AtomicBoolean active = new AtomicBoolean();
+
+        private final ConnectionContext context;
+
+        RequestQueue(ConnectionContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void run() {
+
+            Runnable nextCommand = this.requestQueue.poll();
+
+            if (nextCommand != null) {
+
+                if (DEBUG_ENABLED) {
+                    logger.debug(this.context.getMessage("Initiating queued exchange"));
+                }
+
+                nextCommand.run();
+                return;
             }
-        };
+
+            if (DEBUG_ENABLED) {
+                logger.debug(this.context.getMessage("Conversation complete"));
+            }
+
+            this.active.compareAndSet(true, false);
+        }
+
+        /**
+         * Submit a {@code exchangeRequest}. Requests are either executed directly (without an active exchange) or queued (if another exchange is currently active).
+         *
+         * @param exchangeRequest
+         */
+        void submit(Runnable exchangeRequest) {
+
+            if (this.active.compareAndSet(false, true)) {
+
+                if (DEBUG_ENABLED) {
+                    logger.debug(this.context.getMessage("Initiating exchange"));
+                }
+
+                exchangeRequest.run();
+            } else {
+
+                if (DEBUG_ENABLED) {
+                    logger.debug(this.context.getMessage("Queueing exchange"));
+                }
+
+                if (!this.requestQueue.offer(exchangeRequest)) {
+                    throw new IllegalStateException("Request queue is full");
+                }
+
+                drainRequestQueue();
+            }
+        }
+
+        void drainRequestQueue() {
+
+            if (this.active.compareAndSet(false, true)) {
+
+                Runnable runnable = this.requestQueue.poll();
+
+                if (runnable != null) {
+                    runnable.run();
+                } else {
+                    this.active.compareAndSet(true, false);
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensure a command request is submitted and subscribed to only once.
+     */
+    static class ExchangeRequest {
+
+        private static final AtomicIntegerFieldUpdater<ExchangeRequest> COMPLETED = AtomicIntegerFieldUpdater.newUpdater(ExchangeRequest.class, "completed");
+
+        private static final AtomicIntegerFieldUpdater<ExchangeRequest> SUBMITTED = AtomicIntegerFieldUpdater.newUpdater(ExchangeRequest.class, "submitted");
+
+        private volatile int completed = 0;
+
+        private volatile int submitted = 0;
+
+        public void complete() {
+            COMPLETED.set(this, 1);
+        }
+
+        public boolean isComplete() {
+            return COMPLETED.get(this) == 1;
+        }
+
+        void submit(RequestQueue queue, MonoSink<Flux<Message>> sink, Flux<Message> requestMessages) {
+
+            if (!SUBMITTED.compareAndSet(this, 0, 1)) {
+                throw new IllegalStateException("Client exchange can be subscribed only once");
+            }
+
+            queue.submit(() -> sink.success(requestMessages));
+        }
     }
 
     class TransactionListener implements EnvironmentChangeListener {
@@ -570,7 +683,7 @@ public final class ReactorNettyClient implements Client {
             if (token.getChangeType() == EnvChangeToken.EnvChangeType.CommitTx) {
 
                 if (DEBUG_ENABLED) {
-                    logger.debug(context.getMessage("Transaction committed"));
+                    logger.debug(ReactorNettyClient.this.context.getMessage("Transaction committed"));
                 }
 
                 updateStatus(TransactionStatus.EXPLICIT, TransactionDescriptor.empty());
@@ -579,7 +692,7 @@ public final class ReactorNettyClient implements Client {
             if (token.getChangeType() == EnvChangeToken.EnvChangeType.RollbackTx) {
 
                 if (DEBUG_ENABLED) {
-                    logger.debug(context.getMessage("Transaction rolled back"));
+                    logger.debug(ReactorNettyClient.this.context.getMessage("Transaction rolled back"));
                 }
 
                 updateStatus(TransactionStatus.EXPLICIT, TransactionDescriptor.empty());

--- a/src/main/java/io/r2dbc/mssql/util/FluxDiscardOnCancel.java
+++ b/src/main/java/io/r2dbc/mssql/util/FluxDiscardOnCancel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/r2dbc/mssql/util/FluxDiscardOnCancel.java
+++ b/src/main/java/io/r2dbc/mssql/util/FluxDiscardOnCancel.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.util;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A decorating operator that replays signals from its source to a {@link Subscriber} and drains the source upon {@link Subscription#cancel() cancel} and drops data signals until termination.
+ * Draining data is required to complete a particular request/response window and clear the protocol state as client code expects to start a request/response conversation without any previous
+ * response state.
+ *
+ * @author Mark Paluch
+ */
+class FluxDiscardOnCancel<T> extends FluxOperator<T, T> {
+
+    FluxDiscardOnCancel(Flux<? extends T> source) {
+        super(source);
+        onAssembly(this);
+    }
+
+    @Override
+    public void subscribe(CoreSubscriber<? super T> actual) {
+        source.subscribe(new FluxDiscardOnCancelSubscriber<>(actual));
+    }
+
+    static class FluxDiscardOnCancelSubscriber<T> extends AtomicBoolean implements CoreSubscriber<T>, Subscription {
+
+        final CoreSubscriber<T> actual;
+
+        final Context ctx;
+
+        Subscription s;
+
+        volatile boolean cancelled;
+
+        FluxDiscardOnCancelSubscriber(CoreSubscriber<T> actual) {
+
+            this.actual = actual;
+            this.ctx = actual.currentContext();
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+
+            if (Operators.validate(this.s, s)) {
+                this.s = s;
+                actual.onSubscribe(this);
+            }
+        }
+
+        @Override
+        public void onNext(T t) {
+
+            if (cancelled) {
+                Operators.onDiscard(t, this.ctx);
+                return;
+            }
+
+            actual.onNext(t);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            actual.onError(t);
+        }
+
+        @Override
+        public void onComplete() {
+            actual.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            s.request(n);
+        }
+
+        @Override
+        public void cancel() {
+
+            if (compareAndSet(false, true)) {
+                this.cancelled = true;
+                s.request(Long.MAX_VALUE);
+            }
+        }
+    }
+}

--- a/src/main/java/io/r2dbc/mssql/util/Operators.java
+++ b/src/main/java/io/r2dbc/mssql/util/Operators.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/r2dbc/mssql/util/Operators.java
+++ b/src/main/java/io/r2dbc/mssql/util/Operators.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.util;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * Operator utility.
+ *
+ * @author Mark Paluch
+ */
+public final class Operators {
+
+    private Operators() {
+    }
+
+    /**
+     * Replay signals from {@link Flux the source} until cancellation. Drains the source for data signals if the subscriber cancels the subscription.
+     * <p>
+     * Draining data is required to complete a particular request/response window and clear the protocol state as client code expects to start a request/response conversation without any previous
+     *
+     * @param source
+     * @param <T>
+     * @return
+     */
+    public static <T> Flux<T> discardOnCancel(Flux<? extends T> source) {
+        return new FluxDiscardOnCancel<>(source);
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/ConcurrentAccessIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/ConcurrentAccessIntegrationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.r2dbc.mssql.util.IntegrationTestSupport;
+import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.Result;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Integration tests for multiple active subscriptions.
+ *
+ * @author Mark Paluch
+ */
+class ConcurrentAccessIntegrationTests extends IntegrationTestSupport {
+
+    @Test
+    void shouldSerializeMultipleActiveSubscriptions() {
+
+        createTable(connection);
+        connection.beginTransaction().as(StepVerifier::create).verifyComplete();
+
+        Flux<Integer> insertOne = insertRecord(connection, 1);
+        Flux<Integer> insertTwo = insertRecord(connection, 2);
+        Flux<Integer> insertThree = insertRecord(connection, 3);
+
+        Flux.merge(insertOne, insertTwo, insertThree).as(StepVerifier::create).expectNextCount(3).verifyComplete();
+
+        connection.commitTransaction().as(StepVerifier::create).verifyComplete();
+
+        connection.createStatement("SELECT * FROM r2dbc_example ORDER BY first_name")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> {
+
+                Map<String, Object> values = new LinkedHashMap<>();
+
+                for (ColumnMetadata column : rowMetadata.getColumnMetadatas()) {
+                    values.put(column.getName(), row.get(column.getName()));
+                }
+
+                return values;
+            }))
+            .as(StepVerifier::create)
+            .expectNextCount(3)
+            .verifyComplete();
+    }
+
+    private void createTable(MssqlConnection connection) {
+
+        connection.createStatement("DROP TABLE r2dbc_example").execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .onErrorResume(e -> Mono.empty())
+            .thenMany(connection.createStatement("CREATE TABLE r2dbc_example (" +
+                "id int PRIMARY KEY, " +
+                "first_name varchar(255), " +
+                "last_name varchar(255))")
+                .execute().flatMap(MssqlResult::getRowsUpdated).then())
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    private Flux<Integer> insertRecord(MssqlConnection connection, int id) {
+
+        return connection.createStatement("INSERT INTO r2dbc_example VALUES(@id, @firstname, @lastname)")
+            .bind("id", id)
+            .bind("firstname", "Walter")
+            .bind("lastname", "White")
+            .execute()
+            .flatMap(Result::getRowsUpdated);
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/MssqlCancelIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlCancelIntegrationTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.r2dbc.mssql.util.IntegrationTestSupport;
+import io.r2dbc.spi.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * Integration tests for {@link Subscription subscription cancellation} {@link MssqlConnection} and {@link MssqlStatement}.
+ *
+ * @author Mark Paluch
+ * TODO: Cancellation drops Connection but the connection needs to close a cursor and drain the results before a connection can be used again.
+ * We need some mechanism to indicate the connection is busy with a conversation and then to release the connection again so subsequent conversations may start.
+ */
+class MssqlCancelIntegrationTests extends IntegrationTestSupport {
+
+    static boolean initialized = true;
+
+    @BeforeEach
+    void setUp() {
+
+        if (!initialized) {
+
+            createTable(connection, "r2dbc_example");
+            createTable(connection, "r2dbc_empty");
+
+            for (int i = 0; i < 100; i++) {
+                insertRecord(connection, i);
+            }
+
+            initialized = true;
+        }
+    }
+
+    @Test
+    void shouldCancelUnparametrizedBatch() {
+
+        connection.createStatement("SELECT * FROM r2dbc_example")
+            .fetchSize(0)
+            .execute()
+            .concatMap(it -> it.map((row, metadata) -> row.get("id", Integer.class)))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(1)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+
+        waitSometime();
+
+        connection.createStatement("SELECT * FROM r2dbc_empty")
+            .execute()
+            .flatMap(it -> it.map((row, metadata) -> row.get("id")))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldCancelUnparametrizedCursoredBatch() {
+
+        connection.createStatement("SELECT * FROM r2dbc_example")
+            .fetchSize(10)
+            .execute()
+            .concatMap(it -> it.map((row, metadata) -> row.get("id", Integer.class)))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(1)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+
+        waitSometime();
+
+        connection.createStatement("SELECT * FROM r2dbc_empty")
+            .execute()
+            .flatMap(it -> it.map((row, metadata) -> row.get("id")))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldCancelParametrizedBatch() {
+
+        connection.createStatement("SELECT * FROM r2dbc_example where id != @P1")
+            .bind("@P1", -1)
+            .fetchSize(0)
+            .execute()
+            .concatMap(it -> it.map((row, metadata) -> row.get("id", Integer.class)))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(1)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+
+        waitSometime();
+
+        connection.createStatement("SELECT * FROM r2dbc_empty")
+            .execute()
+            .flatMap(it -> it.map((row, metadata) -> row.get("id")))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldCancelParametrizedCursoredBatch() {
+
+        connection.createStatement("SELECT * FROM r2dbc_example where id != @P1")
+            .bind("@P1", -1)
+            .fetchSize(10)
+            .execute()
+            .concatMap(it -> it.map((row, metadata) -> row.get("id", Integer.class)))
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(1)
+            .expectNextCount(1)
+            .thenCancel()
+            .verify();
+
+        waitSometime();
+
+        connection.createStatement("SELECT * FROM r2dbc_empty")
+            .execute()
+            .flatMap(it -> it.map((row, metadata) -> row.get("id")))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    private void createTable(MssqlConnection connection, String table) {
+
+        connection.createStatement("DROP TABLE " + table).execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .onErrorResume(e -> Mono.empty())
+            .thenMany(connection.createStatement("CREATE TABLE " + table + " (" +
+                "id int PRIMARY KEY, " +
+                "first_name varchar(255), " +
+                "last_name varchar(255))")
+                .execute().flatMap(MssqlResult::getRowsUpdated).then())
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    private void insertRecord(MssqlConnection connection, int id) {
+
+        Flux.from(connection.createStatement("INSERT INTO r2dbc_example VALUES(@id, @firstname, @lastname)")
+            .bind("id", id)
+            .bind("firstname", "Walter")
+            .bind("lastname", "White")
+            .execute())
+            .flatMap(Result::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext(1)
+            .verifyComplete();
+    }
+
+    // Await some time so the Client gets a chance to release its cursor.
+    private void waitSometime() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/MssqlCancelIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlCancelIntegrationTests.java
@@ -29,12 +29,10 @@ import reactor.test.StepVerifier;
  * Integration tests for {@link Subscription subscription cancellation} {@link MssqlConnection} and {@link MssqlStatement}.
  *
  * @author Mark Paluch
- * TODO: Cancellation drops Connection but the connection needs to close a cursor and drain the results before a connection can be used again.
- * We need some mechanism to indicate the connection is busy with a conversation and then to release the connection again so subsequent conversations may start.
  */
 class MssqlCancelIntegrationTests extends IntegrationTestSupport {
 
-    static boolean initialized = true;
+    static boolean initialized = false;
 
     @BeforeEach
     void setUp() {
@@ -65,8 +63,6 @@ class MssqlCancelIntegrationTests extends IntegrationTestSupport {
             .thenCancel()
             .verify();
 
-        waitSometime();
-
         connection.createStatement("SELECT * FROM r2dbc_empty")
             .execute()
             .flatMap(it -> it.map((row, metadata) -> row.get("id")))
@@ -86,8 +82,6 @@ class MssqlCancelIntegrationTests extends IntegrationTestSupport {
             .expectNextCount(1)
             .thenCancel()
             .verify();
-
-        waitSometime();
 
         connection.createStatement("SELECT * FROM r2dbc_empty")
             .execute()
@@ -110,8 +104,6 @@ class MssqlCancelIntegrationTests extends IntegrationTestSupport {
             .thenCancel()
             .verify();
 
-        waitSometime();
-
         connection.createStatement("SELECT * FROM r2dbc_empty")
             .execute()
             .flatMap(it -> it.map((row, metadata) -> row.get("id")))
@@ -132,8 +124,6 @@ class MssqlCancelIntegrationTests extends IntegrationTestSupport {
             .expectNextCount(1)
             .thenCancel()
             .verify();
-
-        waitSometime();
 
         connection.createStatement("SELECT * FROM r2dbc_empty")
             .execute()
@@ -167,14 +157,5 @@ class MssqlCancelIntegrationTests extends IntegrationTestSupport {
             .as(StepVerifier::create)
             .expectNext(1)
             .verifyComplete();
-    }
-
-    // Await some time so the Client gets a chance to release its cursor.
-    private void waitSometime() {
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/src/test/java/io/r2dbc/mssql/QueryMessageFlowUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/QueryMessageFlowUnitTests.java
@@ -18,15 +18,17 @@ package io.r2dbc.mssql;
 
 import io.r2dbc.mssql.client.Client;
 import io.r2dbc.mssql.client.ConnectionContext;
-import io.r2dbc.mssql.message.ClientMessage;
 import io.r2dbc.mssql.message.TransactionDescriptor;
 import io.r2dbc.mssql.message.token.DoneInProcToken;
 import io.r2dbc.mssql.message.token.DoneProcToken;
 import io.r2dbc.mssql.message.token.DoneToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+
+import java.util.function.Predicate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -37,6 +39,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Mark Paluch
  */
+@SuppressWarnings("unchecked")
 class QueryMessageFlowUnitTests {
 
     Client client = mock(Client.class);
@@ -50,7 +53,7 @@ class QueryMessageFlowUnitTests {
     @Test
     void shouldAwaitDoneProcTokenShouldNotCompleteFlow() {
 
-        when(client.exchange(any(ClientMessage.class))).thenReturn(Flux.just(DoneToken.more(20), DoneProcToken.create(0), DoneInProcToken.create(0)));
+        when(client.exchange(any(Publisher.class), any(Predicate.class))).thenReturn(Flux.just(DoneToken.more(20), DoneProcToken.create(0), DoneInProcToken.create(0)));
 
         QueryMessageFlow.exchange(client, "foo")
             .as(StepVerifier::create)
@@ -62,7 +65,7 @@ class QueryMessageFlowUnitTests {
     @Test
     void shouldAwaitDoneToken() {
 
-        when(client.exchange(any(ClientMessage.class))).thenReturn(Flux.just(DoneInProcToken.create(0), DoneToken.create(0)));
+        when(client.exchange(any(Publisher.class), any(Predicate.class))).thenReturn(Flux.just(DoneInProcToken.create(0), DoneToken.create(0)));
 
         QueryMessageFlow.exchange(client, "foo")
             .as(StepVerifier::create)

--- a/src/test/java/io/r2dbc/mssql/SimpleMssqlStatementUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/SimpleMssqlStatementUnitTests.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.util.annotation.Nullable;
 
@@ -53,6 +54,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static io.r2dbc.mssql.message.type.TypeInformation.Builder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,7 +156,7 @@ class SimpleMssqlStatementUnitTests {
 
         ArgumentCaptor<Publisher<Message>> captor = ArgumentCaptor.forClass(Publisher.class);
 
-        verify(client).exchange((Publisher) captor.capture());
+        verify(client).exchange((Publisher) captor.capture(), any(Predicate.class));
 
         StepVerifier.create(captor.getValue())
             .consumeNextWith(it -> assertThat(it)
@@ -174,10 +176,10 @@ class SimpleMssqlStatementUnitTests {
         statement.execute().as(StepVerifier::create)
             .verifyComplete();
 
-        ArgumentCaptor<ClientMessage> captor = ArgumentCaptor.forClass(ClientMessage.class);
+        ArgumentCaptor<Mono<ClientMessage>> captor = ArgumentCaptor.forClass(Mono.class);
 
-        verify(client).exchange(captor.capture());
-        assertThat(captor.getValue()).isInstanceOf(SqlBatch.class);
+        verify(client).exchange(captor.capture(), any(Predicate.class));
+        assertThat(captor.getValue().block()).isInstanceOf(SqlBatch.class);
     }
 
     @Test
@@ -191,10 +193,10 @@ class SimpleMssqlStatementUnitTests {
         statement.execute().as(StepVerifier::create)
             .verifyComplete();
 
-        ArgumentCaptor<ClientMessage> captor = ArgumentCaptor.forClass(ClientMessage.class);
+        ArgumentCaptor<Mono<ClientMessage>> captor = ArgumentCaptor.forClass(Mono.class);
 
-        verify(client).exchange(captor.capture());
-        assertThat(captor.getValue()).isInstanceOf(SqlBatch.class);
+        verify(client).exchange(captor.capture(), any(Predicate.class));
+        assertThat(captor.getValue().block()).isInstanceOf(SqlBatch.class);
     }
 
     @Test
@@ -210,7 +212,7 @@ class SimpleMssqlStatementUnitTests {
 
         ArgumentCaptor<Publisher<Message>> captor = ArgumentCaptor.forClass(Publisher.class);
 
-        verify(client).exchange((Publisher) captor.capture());
+        verify(client).exchange((Publisher) captor.capture(), any(Predicate.class));
 
         StepVerifier.create(captor.getValue())
             .consumeNextWith(it -> assertThat(it)
@@ -226,8 +228,7 @@ class SimpleMssqlStatementUnitTests {
 
         when(client.getRequiredCollation()).thenReturn(Collation.RAW);
         when(client.getTransactionDescriptor()).thenReturn(TransactionDescriptor.empty());
-        when(client.exchange(any(ClientMessage.class))).thenReturn(Flux.empty());
-        when(client.exchange(any(Publisher.class))).thenReturn(Flux.empty());
+        when(client.exchange(any(Publisher.class), any(Predicate.class))).thenReturn(Flux.empty());
         when(client.getContext()).thenReturn(new ConnectionContext());
 
         return client;

--- a/src/test/java/io/r2dbc/mssql/client/TestClient.java
+++ b/src/test/java/io/r2dbc/mssql/client/TestClient.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Test {@link Client} implementation.
@@ -91,8 +92,8 @@ public final class TestClient implements Client {
         return this.expectClose ? Mono.empty() : Mono.error(new AssertionError("close called unexpectedly"));
     }
 
-    @Override
-    public Flux<Message> exchange(Publisher<? extends ClientMessage> requests) {
+    public Flux<Message> exchange(Publisher<? extends ClientMessage> requests, Predicate<Message> isLastResponseFrame) {
+
         Assert.requireNonNull(requests, "requests must not be null");
 
         return this.responseProcessor

--- a/src/test/java/io/r2dbc/mssql/util/FluxDiscardOnCancelUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/util/FluxDiscardOnCancelUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/r2dbc/mssql/util/FluxDiscardOnCancelUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/util/FluxDiscardOnCancelUnitTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.util;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link FluxDiscardOnCancel}.
+ *
+ * @author Mark Paluch
+ */
+class FluxDiscardOnCancelUnitTests {
+
+    @Test
+    void shouldEmitAllItemsOnSubscription() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .as(StepVerifier::create)
+            .expectNext(0, 1, 2, 3)
+            .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void considersAssemblyHook() {
+
+        List<Object> publishers = new ArrayList<>();
+        Hooks.onEachOperator(objectPublisher -> {
+            publishers.add(objectPublisher);
+
+            return objectPublisher;
+        });
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .as(StepVerifier::create)
+            .expectNextCount(4)
+            .verifyComplete();
+
+        assertThat(publishers).hasSize(2).extracting(Object::getClass).contains((Class) FluxDiscardOnCancel.class);
+    }
+
+    @Test
+    void considersOnDropHook() {
+
+        List<Object> discard = new ArrayList<>();
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .doOnDiscard(Object.class, discard::add)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(discard).containsOnly(2, 3);
+    }
+
+    @Test
+    void shouldNotConsumeItemsOnCancel() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(items).contains(2, 3);
+    }
+
+    @Test
+    void shouldConsumeAndDiscardItemsOnCancel() {
+
+        Iterator<Integer> items = createItems(4);
+
+        Flux.fromIterable(() -> items)
+            .as(Operators::discardOnCancel)
+            .as(it -> StepVerifier.create(it, 0))
+            .thenRequest(2)
+            .expectNext(0, 1)
+            .thenCancel()
+            .verify();
+
+        assertThat(items).isEmpty();
+    }
+
+    static Iterator<Integer> createItems(int count) {
+        return IntStream.range(0, count).boxed().iterator();
+    }
+}


### PR DESCRIPTION
FluxDiscardOnCancel replays source signals unless canceling
the subscription. On cancellation, the subscriber requests Long.MAX_VALUE
to drain the source and discard elements that are emitted afterward.

TODO:

- [x] add `FluxDiscardOnCancel` operator
- [x] Propagate cancel signal to close cursor
- [ ] Consider connection busy state (state in which a conversation is active on the connection and new commands/conversations cannot be yet accepted). `.cancel()` typically releases a connection and when cursor cleanup is in progress this can lead to race conditions.