### PR TITLE
Include LICENSE.txt and NOTICE files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,16 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>LICENSE.txt</include>
+                    <include>NOTICE</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
     </build>
 
     <repositories>


### PR DESCRIPTION
This change updates the build to include `LICENSE.txt` and `NOTICE` files in compliance with the Apache Software License.

[r2dbc/r2dbc-spi#36]