### PR TITLE
Remove Recursive Generics

### DIFF
--- a/src/main/java/io/r2dbc/mssql/MssqlBatch.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlBatch.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author Mark Paluch
  */
-public final class MssqlBatch implements Batch<MssqlBatch> {
+public final class MssqlBatch implements Batch {
 
     private final Client client;
 

--- a/src/main/java/io/r2dbc/mssql/MssqlConnection.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnection.java
@@ -104,7 +104,7 @@ public final class MssqlConnection implements Connection {
     }
 
     @Override
-    public Batch<?> createBatch() {
+    public Batch createBatch() {
         return new MssqlBatch(this.client, this.codecs);
     }
 
@@ -129,7 +129,7 @@ public final class MssqlConnection implements Connection {
     }
 
     @Override
-    public MssqlStatement<?> createStatement(String sql) {
+    public MssqlStatement createStatement(String sql) {
 
         Assert.requireNonNull(sql, "SQL must not be null");
         this.logger.debug("Creating statement for SQL: [{}]", sql);

--- a/src/main/java/io/r2dbc/mssql/MssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlStatement.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Flux;
  *
  * @author Mark Paluch
  */
-public interface MssqlStatement<SELF extends MssqlStatement<SELF>> extends Statement<SELF> {
+public interface MssqlStatement extends Statement {
 
     /**
      * {@inheritDoc}
@@ -39,7 +39,7 @@ public interface MssqlStatement<SELF extends MssqlStatement<SELF>> extends State
      *                                  etc.
      */
     @Override
-    SELF bind(Object identifier, Object value);
+    Statement bind(Object identifier, Object value);
 
     /**
      * {@inheritDoc}
@@ -48,7 +48,7 @@ public interface MssqlStatement<SELF extends MssqlStatement<SELF>> extends State
      *                                  etc.
      */
     @Override
-    SELF bindNull(Object identifier, Class<?> type);
+    Statement bindNull(Object identifier, Class<?> type);
 
     @Override
     Flux<MssqlResult> execute();

--- a/src/main/java/io/r2dbc/mssql/PreparedMssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/PreparedMssqlStatement.java
@@ -53,7 +53,7 @@ import java.util.regex.Pattern;
  *
  * @author Mark Paluch
  */
-final class PreparedMssqlStatement implements MssqlStatement<PreparedMssqlStatement> {
+final class PreparedMssqlStatement implements MssqlStatement {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/main/java/io/r2dbc/mssql/SimpleMssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/SimpleMssqlStatement.java
@@ -30,7 +30,7 @@ import reactor.core.publisher.Flux;
  *
  * @author Mark Paluch
  */
-class SimpleMssqlStatement implements MssqlStatement<SimpleMssqlStatement> {
+class SimpleMssqlStatement implements MssqlStatement {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/test/java/io/r2dbc/mssql/CodecIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/CodecIntegrationTests.java
@@ -18,7 +18,9 @@ package io.r2dbc.mssql;
 
 import io.r2dbc.mssql.codec.DefaultCodecs;
 import io.r2dbc.mssql.util.IntegrationTestSupport;
+import io.r2dbc.spi.Result;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -146,10 +148,10 @@ class CodecIntegrationTests extends IntegrationTestSupport {
 
         createTable(connection, columnType);
 
-        connection.createStatement("INSERT INTO codec_test values(@P0)")
+        Flux.from(connection.createStatement("INSERT INTO codec_test values(@P0)")
             .bind("P0", value)
-            .execute()
-            .flatMap(MssqlResult::getRowsUpdated)
+            .execute())
+            .flatMap(Result::getRowsUpdated)
             .as(StepVerifier::create)
             .expectNext(1)
             .verifyComplete();
@@ -168,10 +170,10 @@ class CodecIntegrationTests extends IntegrationTestSupport {
             .expectNext(expectedGetObjectValue)
             .verifyComplete();
 
-        connection.createStatement("UPDATE codec_test SET my_col = @P0")
+        Flux.from(connection.createStatement("UPDATE codec_test SET my_col = @P0")
             .bindNull("P0", value.getClass())
-            .execute()
-            .flatMap(MssqlResult::getRowsUpdated)
+            .execute())
+            .flatMap(Result::getRowsUpdated)
             .as(StepVerifier::create)
             .expectNext(1)
             .verifyComplete();

--- a/src/test/java/io/r2dbc/mssql/PreparedMssqlStatementIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/PreparedMssqlStatementIntegrationTests.java
@@ -17,7 +17,9 @@
 package io.r2dbc.mssql;
 
 import io.r2dbc.mssql.util.IntegrationTestSupport;
+import io.r2dbc.spi.Result;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -42,12 +44,12 @@ class PreparedMssqlStatementIntegrationTests extends IntegrationTestSupport {
             .as(StepVerifier::create)
             .verifyComplete();
 
-        connection.createStatement("INSERT INTO r2dbc_example (first_name, last_name) values (@fn, @ln)")
+        Flux.from(connection.createStatement("INSERT INTO r2dbc_example (first_name, last_name) values (@fn, @ln)")
             .bind("fn", "Walter").bind("ln", "White").add()
             .bind("fn", "Hank").bind("ln", "Schrader").add()
             .bind("fn", "Skyler").bind("ln", "White")
-            .execute()
-            .flatMap(MssqlResult::getRowsUpdated)
+            .execute())
+            .flatMap(Result::getRowsUpdated)
             .as(StepVerifier::create)
             .expectNext(1, 1, 1)
             .verifyComplete();


### PR DESCRIPTION
This change removes the recursive generics from this implementation to be compliant with changes made to the SPI.  These changes were driven by the observation that recursive generics made consumption of the API harder and no longer provided us much value.

[r2dbc/r2dbc-spi#24]

Signed-off-by: Ben Hale <bhale@pivotal.io>