### PR TITLE
Example Tests

### DIFF
--- a/src/test/java/io/r2dbc/mssql/MssqlExample.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlExample.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.r2dbc.mssql.util.MsSqlServerExtension;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.test.Example;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.jdbc.core.JdbcOperations;
+
+import static io.r2dbc.mssql.MssqlConnectionFactoryProvider.MSSQL_DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+
+final class MssqlExample implements Example<String> {
+
+    @RegisterExtension
+    static final MsSqlServerExtension SERVER = new MsSqlServerExtension();
+
+    private final ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        .option(DRIVER, MSSQL_DRIVER)
+        .option(HOST, SERVER.getHost())
+        .option(PORT, SERVER.getPort())
+        .option(PASSWORD, SERVER.getPassword())
+        .option(USER, SERVER.getUsername())
+        .build());
+
+    @Override
+    public String blobType() {
+        return "VARBINARY(MAX)";
+    }
+
+    @Override
+    public String clobType() {
+        return "VARCHAR(MAX)";
+    }
+
+    @Override
+    public ConnectionFactory getConnectionFactory() {
+        return this.connectionFactory;
+    }
+
+    @Override
+    public String getIdentifier(int index) {
+        return getPlaceholder(index);
+    }
+
+    @Override
+    public JdbcOperations getJdbcOperations() {
+        JdbcOperations jdbcOperations = SERVER.getJdbcOperations();
+
+        if (jdbcOperations == null) {
+            throw new IllegalStateException("JdbcOperations not yet initialized");
+        }
+
+        return jdbcOperations;
+    }
+
+    @Override
+    public String getPlaceholder(int index) {
+        return String.format("@P%d", index);
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/util/MsSqlServerExtension.java
+++ b/src/test/java/io/r2dbc/mssql/util/MsSqlServerExtension.java
@@ -16,11 +16,16 @@
 
 package io.r2dbc.mssql.util;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MSSQLServerContainer;
+import reactor.util.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -40,6 +45,10 @@ public final class MsSqlServerExtension implements BeforeAllCallback, AfterAllCa
         }
     };
 
+    private HikariDataSource dataSource;
+
+    private JdbcOperations jdbcOperations;
+
     private final DatabaseContainer sqlServer = External.INSTANCE.isAvailable() ? External.INSTANCE : new TestContainer(container);
 
     private final boolean useTestContainer = sqlServer instanceof TestContainer;
@@ -50,6 +59,17 @@ public final class MsSqlServerExtension implements BeforeAllCallback, AfterAllCa
         if (this.useTestContainer) {
             this.container.start();
         }
+
+        this.dataSource = DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .url(this.container.getJdbcUrl())
+            .username(this.container.getUsername())
+            .password(this.container.getPassword())
+            .build();
+
+        this.dataSource.setMaximumPoolSize(1);
+
+        this.jdbcOperations = new JdbcTemplate(this.dataSource);
     }
 
     @Override
@@ -62,6 +82,11 @@ public final class MsSqlServerExtension implements BeforeAllCallback, AfterAllCa
 
     public String getHost() {
         return this.sqlServer.getHost();
+    }
+
+    @Nullable
+    public JdbcOperations getJdbcOperations() {
+        return this.jdbcOperations;
     }
 
     public String getPassword() {


### PR DESCRIPTION
Previously the the driver implementation didn't run the shared Examples tests which act as a TCK.  This change adds these tests, but beware that they fail without a BLOB/CLOB implementation.
