### PR TITLE
Fix infinite loop when clearing bindings

### DIFF
--- a/src/main/java/io/r2dbc/mssql/ParametrizedMssqlStatement.java
+++ b/src/main/java/io/r2dbc/mssql/ParametrizedMssqlStatement.java
@@ -176,7 +176,8 @@ final class ParametrizedMssqlStatement extends MssqlStatementSupport implements 
     private void clearBindings(Iterator<Binding> iterator) {
 
         while (iterator.hasNext()) {
-            // exhaust iterator
+            // exhaust iterator, ignore returned elements
+            iterator.next();
         }
 
         this.bindings.clear();


### PR DESCRIPTION
#### Issue description

It is the Obvious Fix.

The `ParametrizedMssqlStatement.clearBindings(Iterator<Binding>)` exhaust 
iterator like following:

```
private void clearBindings(Iterator<Binding> iterator) {

    while (iterator.hasNext()) {
        // exhaust iterator
    }

    this.bindings.clear();
}
```

The variable `iterator` is not updated inside the loop, so it could be an infinite loop.

Should use `iterator.next()` inside the loop to exhaust `iterator` and ignore the returned elements.
 
#### New Public APIs

None.

#### Additional context

None.
