### PR TITLE
Add support for configuring a custom trust store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <spring-framework.version>5.2.3.RELEASE</spring-framework.version>
         <testcontainers.version>1.13.0</testcontainers.version>
+        <bouncycastle.version>1.64</bouncycastle.version>
     </properties>
 
     <licenses>
@@ -208,6 +209,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/r2dbc/mssql/util/TestCertificateAuthority.java
+++ b/src/test/java/io/r2dbc/mssql/util/TestCertificateAuthority.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.util;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Certificate;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Date;
+
+import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+/**
+ * A certificate authority for testing TLS.
+ */
+public class TestCertificateAuthority {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final long VALID_TIME = (long) 365 * 24 * 60 * 60 * 1000;
+    private final KeyPair keyPair = randomKeyPair();
+    private final String issuerDn;
+    private final KeyStore trustStore;
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public TestCertificateAuthority(final String issuerDn) {
+        this.issuerDn = issuerDn;
+        this.trustStore = createTrustStore(sign(issuerDn, issuerDn, keyPair.getPrivate(), keyPair.getPublic(), true));
+    }
+
+    private static KeyStore createTrustStore(final X509Certificate cert) {
+        try {
+            final KeyStore keystore = KeyStore.getInstance("jks");
+            keystore.load(null, null);
+            keystore.setCertificateEntry("ca", cert);
+            return keystore;
+        } catch (final KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            throw new RuntimeException("Failed to create trust store for test CA");
+        }
+    }
+
+    public ServerKeyPair newServerKeyPair(final String dn) {
+        final KeyPair newKeyPair = randomKeyPair();
+        final X509Certificate cert = sign(dn, issuerDn, keyPair.getPrivate(), newKeyPair.getPublic(), false);
+        return new ServerKeyPair(newKeyPair, cert);
+    }
+
+    private static byte[] toPem(final PrivateKey key) {
+        return toPem(key.getEncoded(), "PRIVATE KEY");
+    }
+
+    private static byte[] toPem(final X509Certificate cert) {
+        try {
+            return toPem(cert.getEncoded(), "CERTIFICATE");
+        } catch (final CertificateEncodingException e) {
+            throw new RuntimeException("Failed to encode certificate", e);
+        }
+    }
+
+    private static byte[] toPem(final byte[] derCert, final String kind) {
+        final String cert_begin = "-----BEGIN " + kind + "-----";
+        final String end_cert = "-----END " + kind + "-----";
+        final String data = Base64.getMimeEncoder(64, "\n".getBytes(US_ASCII)).encodeToString(derCert);
+        return (cert_begin + "\n" + data + "\n" + end_cert + "\n").getBytes(US_ASCII);
+    }
+
+    private static X509Certificate sign(
+            final String ownerDn,
+            final String issuerDn,
+            final PrivateKey signingKey,
+            final PublicKey publicKey,
+            final boolean isTrustAnchor
+    ) {
+        final Date notBefore = new Date(currentTimeMillis());
+        final Date notAfter = new Date(currentTimeMillis() + VALID_TIME);
+        try {
+            final AlgorithmIdentifier sigAlgId = new DefaultSignatureAlgorithmIdentifierFinder()
+                    .find("SHA256withRSA");
+            final AlgorithmIdentifier digAlgId = new DefaultDigestAlgorithmIdentifierFinder()
+                    .find(sigAlgId);
+
+            final X509v3CertificateBuilder certGenerator = new X509v3CertificateBuilder(
+                    new X500Name(issuerDn),
+                    BigInteger.valueOf(SECURE_RANDOM.nextInt()),
+                    notBefore,
+                    notAfter,
+                    new X500Name(ownerDn),
+                    SubjectPublicKeyInfo.getInstance(publicKey.getEncoded())
+            );
+            if (isTrustAnchor) {
+                certGenerator.addExtension(new ASN1ObjectIdentifier("2.5.29.19"), false, new BasicConstraints(true));
+            }
+            final ContentSigner sigGen = new BcRSAContentSignerBuilder(sigAlgId, digAlgId)
+                    .build(PrivateKeyFactory.createKey(signingKey.getEncoded()));
+
+            final X509CertificateHolder holder = certGenerator.build(sigGen);
+            final Certificate eeX509CertificateStructure = holder.toASN1Structure();
+            final CertificateFactory cf = CertificateFactory.getInstance("X.509", "BC");
+
+            try (final InputStream stream = new ByteArrayInputStream(eeX509CertificateStructure.getEncoded())) {
+                return (X509Certificate) cf.generateCertificate(stream);
+            }
+        } catch (final CertificateException | IOException | OperatorCreationException | NoSuchProviderException e) {
+            throw new RuntimeException("Failed to sign certificate", e);
+        }
+    }
+
+    private static KeyPair randomKeyPair() {
+        try {
+            final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(2048);
+            return kpg.generateKeyPair();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new RuntimeException("Could not create keypair for test CA", e);
+        }
+    }
+
+    public KeyStore getTrustStore() {
+        return trustStore;
+    }
+
+    static class ServerKeyPair {
+        private final KeyPair keyPair;
+        private final X509Certificate cert;
+
+        ServerKeyPair(final KeyPair keyPair, final X509Certificate cert) {
+            this.keyPair = keyPair;
+            this.cert = cert;
+        }
+
+        public byte[] getPrivateKey() {
+            return toPem(keyPair.getPrivate());
+        }
+
+        public byte[] getCertificate() {
+            return toPem(cert);
+        }
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/util/TestMsSqlServerContainer.java
+++ b/src/test/java/io/r2dbc/mssql/util/TestMsSqlServerContainer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.util;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import io.r2dbc.mssql.util.TestCertificateAuthority.ServerKeyPair;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Arrays.asList;
+import static java.util.Comparator.reverseOrder;
+
+/**
+ * A MSSQL testcontainer that supports custom TLS certificates.
+ */
+class TestMsSqlServerContainer extends MSSQLServerContainer<TestMsSqlServerContainer> {
+
+    private static final String PATH_CERT = "/cert.pem";
+
+    private static final String PATH_KEY = "/key.pem";
+
+    private static final String PATH_ENTRYPOINT = "/entrypoint.sh";
+
+    private static final String ENTRYPOINT = join("\n", asList(
+        "set -e",
+        "/opt/mssql/bin/mssql-conf set network.tlscert " + PATH_CERT,
+        "/opt/mssql/bin/mssql-conf set network.tlskey " + PATH_KEY,
+        "/opt/mssql/bin/mssql-conf set network.tlsprotocols 1.2",
+        "exec \"$@\""
+    ));
+
+    private final Path tempDir;
+
+    TestMsSqlServerContainer(ServerKeyPair keyPair) {
+        withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(TestMsSqlServerContainer.class)));
+        try {
+            tempDir = Files.createTempDirectory("r2dbc-mssql-test-");
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to create temp directory", e);
+        }
+        withFile(tempDir, PATH_CERT, keyPair.getCertificate());
+        withFile(tempDir, PATH_KEY, keyPair.getPrivateKey());
+        withFile(tempDir, PATH_ENTRYPOINT, ENTRYPOINT.getBytes(US_ASCII));
+        withCreateContainerCmdModifier(cmd -> {
+            cmd.withEntrypoint("sh", PATH_ENTRYPOINT);
+            cmd.withCmd("/opt/mssql/bin/sqlservr");
+        });
+    }
+
+    private void withFile(Path tempDir, String filename, byte[] data) {
+        File tempFile = new File(tempDir.toFile(), filename);
+        try {
+            Files.write(tempFile.toPath(), data);
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to write temp file", e);
+        }
+        withFileSystemBind(tempFile.getPath(), filename);
+    }
+
+    @Override
+    protected void containerIsStopped(InspectContainerResponse containerInfo) {
+        try {
+            Files.walk(tempDir).sorted(reverseOrder()).forEach(it -> it.toFile().delete());
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to delete temp directory", e);
+        }
+    }
+
+    protected void configure() {
+        this.addExposedPort(MS_SQL_SERVER_PORT);
+        this.addEnv("ACCEPT_EULA", "Y");
+        this.addEnv("SA_PASSWORD", getPassword());
+        this.withReuse(true);
+    }
+}


### PR DESCRIPTION
#### Issue description

Resolves #148 

Right now in order to allow validation of custom server certificates, it is necessary to replace the JVM's default trust store. In various situations it is desirable to programmatically set a different trust store specifically for the R2DBC-MSSQL library instead. This PR adds a configuration option to configure such a custom trust store and implements its usage (if set) instead of the JVM's default trust store. 

#### New Public APIs
```
io.r2dbc.mssql.MssqlConnectionConfiguration.Builder#withTrustStore
io.r2dbc.mssql.MssqlConnectionConfiguration.Builder#withTrustStoreType
io.r2dbc.mssql.MssqlConnectionConfiguration.Builder#withTrustStorePassword
```

#### Additional context

The functionality of the implementation is verified by activating the following test case (which used to be disabled before):
```
io.r2dbc.mssql.MssqlConnectionIntegrationTests#shouldInsertAndSelectUsingMapUsingTls
```
The MSSQL testcontainer used for integration testing is configured to use a custom TLS certificate in order to test the functionality.