### PR TITLE
StringCodec fix for characters split between PLP chunks

### DIFF
--- a/src/test/java/io/r2dbc/mssql/codec/StringCodecUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/codec/StringCodecUnitTests.java
@@ -29,6 +29,8 @@ import io.r2dbc.mssql.util.HexUtils;
 import io.r2dbc.mssql.util.TestByteBufAllocator;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static io.r2dbc.mssql.message.type.TypeInformation.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -150,6 +152,24 @@ class StringCodecUnitTests {
         String value = StringCodec.INSTANCE.decode(data, ColumnUtil.createColumn(type), String.class);
 
         assertThat(value).isEqualTo("foobar");
+    }
+
+    @Test
+    void shouldDecodeVarcharMaxSplitCharacter() {
+
+        TypeInformation type =
+            builder().withMaxLength(50).withLengthStrategy(LengthStrategy.PARTLENTYPE).withPrecision(50).withServerType(SqlServerType.NVARCHARMAX).withCharset(StandardCharsets.UTF_16LE).build();
+
+        ByteBuf data = HexUtils.decodeToByteBuf("62 00 00 00 00 00 00 00 " +
+            "2d 00 00 00 " +
+            "6c 00 65 00 61 00 6e 00 6e 00 65 00 2e 00 61 00 73 00 68 00 74 00 6f 00 6e 00 40 00 64 00 64 00 2d 00 70 00 75 00 62 00 2e 00 63 00 6f " +
+            "35 00 00 00 " +
+            "00 6d 00 2c 00 64 00 61 00 76 00 69 00 64 00 2e 00 6d 00 61 00 61 00 73 00 73 00 65 00 6e 00 40 00 64 00 64 00 2d 00 70 00 75 00 62 00 2e 00 63 00 6f 00 6d 00 " +
+            "00 00 00 00");
+
+        String value = StringCodec.INSTANCE.decode(data, ColumnUtil.createColumn(type), String.class);
+
+        assertThat(value).isEqualTo("leanne.ashton@dd-pub.com,david.maassen@dd-pub.com");
     }
 
     @Test


### PR DESCRIPTION
#### Issue description
#169 
 
#### Additional context

StringCodec expects that every PLP chunk of a string is a valid encoded character sequence.
But backend can split one character between PLP chunks. In that case we read half of a character and try decode. There's no error because default action is CodingErrorAction.REPLACE. After that we read next PLP chunk from the middle of a character and that corrupts remaining characters.
So we can't really read any chunk as a String. 
We can accumulate complete string bytes in a CompositeByteBuf and decode it or we can use CharsetDecoder directly and keep track of split characters. I've picked first option here.