### PR TITLE
Fixed ByteBuf releasing after encoding values

### DIFF
--- a/src/jmh/java/io/r2dbc/mssql/PooledBenchmarks.java
+++ b/src/jmh/java/io/r2dbc/mssql/PooledBenchmarks.java
@@ -61,8 +61,7 @@ public class PooledBenchmarks extends BenchmarkSettings {
 
             this.jdbc = extension.getDataSource();
 
-            MssqlConnectionConfiguration configuration =
-                MssqlConnectionConfiguration.builder().host(extension.getHost()).username(extension.getUsername()).password(extension.getPassword()).build();
+            MssqlConnectionConfiguration configuration = extension.configBuilder().build();
 
             MssqlConnectionFactory mssqlConnectionFactory = new MssqlConnectionFactory(configuration);
             ConnectionPoolConfiguration poolConfiguration = ConnectionPoolConfiguration.builder(mssqlConnectionFactory).maxSize(4).build();
@@ -90,6 +89,7 @@ public class PooledBenchmarks extends BenchmarkSettings {
     }
 
     @Benchmark
+    @Testable
     public void simpleDirectR2dbc(ConnectionHolder connectionHolder, Blackhole voodoo) {
 
         String optname = Mono.usingWhen(connectionHolder.r2dbc.create(), connection -> {

--- a/src/main/java/io/r2dbc/mssql/codec/BlobCodec.java
+++ b/src/main/java/io/r2dbc/mssql/codec/BlobCodec.java
@@ -166,9 +166,14 @@ public class BlobCodec extends AbstractCodec<Blob> {
                 result.flip();
                 return result;
             })
-                .doOnDiscard(ByteBuf.class, ByteBuf::release)
+                .doOnDiscard(ByteBuf.class, buffer ->
+                    {
+                        if (buffer.refCnt() > 0) {
+                            buffer.release();
+                        }
+                    }
+                )
                 .doOnCancel(() -> {
-
                     for (ByteBuf buffer : this.buffers) {
                         if (buffer.refCnt() > 0) {
                             buffer.release();

--- a/src/main/java/io/r2dbc/mssql/codec/ByteArray.java
+++ b/src/main/java/io/r2dbc/mssql/codec/ByteArray.java
@@ -42,10 +42,14 @@ abstract class ByteArray {
 
         Encoded encoded = encodeFunction.apply(ByteBufAllocator.DEFAULT);
 
+        ByteBuf buffer = null;
         try {
-            return ByteBufUtil.getBytes(encoded.getValue());
+            buffer = encoded.getValue();
+            return ByteBufUtil.getBytes(buffer);
         } finally {
-            encoded.dispose();
+            if (buffer != null && buffer.refCnt() > 0) {
+                buffer.release();
+            }
         }
     }
 

--- a/src/main/java/io/r2dbc/mssql/message/token/Attention.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/Attention.java
@@ -79,6 +79,10 @@ public final class Attention implements ClientMessage, TokenStream {
         ByteBuf buffer = allocator.buffer(length);
         encode(buffer);
 
+        if(buffer.refCnt() > 0) {
+            buffer.release();
+        }
+
         return TdsPackets.create(header, Unpooled.EMPTY_BUFFER);
     }
 

--- a/src/test/java/io/r2dbc/mssql/message/token/RowTokenUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/RowTokenUnitTests.java
@@ -67,6 +67,7 @@ class RowTokenUnitTests {
         assertThat(rowToken.getColumnData(1)).isNotNull();
         assertThat(rowToken.getColumnData(2)).isNotNull();
         assertThat(rowToken.getColumnData(3)).isNotNull();
+        buffer.release();
     }
 
     @Test
@@ -111,6 +112,9 @@ class RowTokenUnitTests {
 
         assertThat(row.getColumnData(0).readableBytes()).isEqualTo(5);
         assertThat(row.getColumnData(1).readableBytes()).isEqualTo(10016);
+
+        rowData.release();
+        row.release();
     }
 
     @Test
@@ -129,6 +133,9 @@ class RowTokenUnitTests {
 
         assertThat(row.getColumnData(0).readableBytes()).isEqualTo(5);
         assertThat(row.getColumnData(1)).isNull();
+
+        rowData.release();
+        row.release();
     }
 
     @Test
@@ -143,6 +150,7 @@ class RowTokenUnitTests {
 
         ByteBuf rowData = loadRowData("int-varcharmax-data.txt");
         CanDecodeTestSupport.testCanDecode(rowData, buffer -> RowToken.canDecode(buffer, columns.getColumns()));
+        rowData.release();
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/util/EncodedAssert.java
+++ b/src/test/java/io/r2dbc/mssql/util/EncodedAssert.java
@@ -119,6 +119,10 @@ public final class EncodedAssert extends AbstractObjectAssert<EncodedAssert, Byt
         Assertions.assertThat(ByteBufUtil.prettyHexDump(this.actual)).describedAs("ByteBuf")
             .isEqualTo(ByteBufUtil.prettyHexDump(expected));
 
+        if(this.actual.refCnt()>0){
+            this.actual.release();
+        }
+
         return this;
     }
 }

--- a/src/test/java/io/r2dbc/mssql/util/MsSqlServerExtension.java
+++ b/src/test/java/io/r2dbc/mssql/util/MsSqlServerExtension.java
@@ -90,7 +90,7 @@ public final class MsSqlServerExtension implements BeforeAllCallback, AfterAllCa
     }
 
     public MssqlConnectionConfiguration.Builder configBuilder() {
-        return MssqlConnectionConfiguration.builder().host(getHost()).username(getUsername()).password(getPassword());
+        return MssqlConnectionConfiguration.builder().host(getHost()).port(getPort()).username(getUsername()).password(getPassword());
     }
 
     public MssqlConnectionConfiguration getConnectionConfiguration() {


### PR DESCRIPTION
<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.

- This is bug fix, no feature request created.

- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

- Reused existing test cases

 <!--
Great! Live long and prosper.
-->

#### Issue description

This PR fixes all ByteBuf leak warnings that were visible both during test execution and in application runtime. Around 41 individual leaks were identified and corrected, ensuring proper reference counting and buffer release.

Fixed ~41 ByteBuf leaks discovered during tests.
Corrected improper buffer handling in application paths where leaks were visible at runtime.

All these warning have been fixed:

<img width="1690" height="827" alt="image" src="https://github.com/user-attachments/assets/645758a7-297b-4700-be78-124fc04bda82" /> 

#### New Public APIs

No new public APIs introduced or modified.

#### Additional context

Running all test with:

```
-ea
-Dio.netty.leakDetection.level=PARANOID
-Dio.netty.recycler.maxCapacityPerThread=0
```
