### PR TITLE
Fixed `Too Many Parameters` error #276 | Using connection id in the cache key

### DIFF
--- a/src/jmh/java/io/r2dbc/mssql/ParametrizedMssqlStatementBenchmarks.java
+++ b/src/jmh/java/io/r2dbc/mssql/ParametrizedMssqlStatementBenchmarks.java
@@ -37,12 +37,12 @@ public class ParametrizedMssqlStatementBenchmarks extends BenchmarkSettings {
     private static final ConnectionOptions uncached = new ConnectionOptions(s -> false, new DefaultCodecs(), new PreparedStatementCache() {
 
         @Override
-        public int getHandle(String sql, Binding binding) {
+        public int getHandle(Object connectionKey, String sql, Binding binding) {
             return 0;
         }
 
         @Override
-        public void putHandle(int handle, String sql, Binding binding) {
+        public void putHandle(Object connectionKey, int handle, String sql, Binding binding) {
         }
 
         @Override

--- a/src/main/java/io/r2dbc/mssql/IndefinitePreparedStatementCache.java
+++ b/src/main/java/io/r2dbc/mssql/IndefinitePreparedStatementCache.java
@@ -34,21 +34,23 @@ class IndefinitePreparedStatementCache implements PreparedStatementCache {
     private final Map<String, Object> parsedSql = new ConcurrentHashMap<>();
 
     @Override
-    public int getHandle(String sql, Binding binding) {
+    public int getHandle(Object connectionKey, String sql, Binding binding) {
 
+        Assert.requireNonNull(connectionKey, "Connection key must not be null");
         Assert.requireNonNull(sql, "SQL query must not be null");
         Assert.requireNonNull(binding, "Binding query must not be null");
 
-        return this.preparedStatements.getOrDefault(createKey(sql, binding), UNPREPARED);
+        return this.preparedStatements.getOrDefault(createKey(connectionKey, sql, binding), UNPREPARED);
     }
 
     @Override
-    public void putHandle(int handle, String sql, Binding binding) {
+    public void putHandle(Object connectionKey, int handle, String sql, Binding binding) {
 
+        Assert.requireNonNull(connectionKey, "Connection key must not be null");
         Assert.requireNonNull(sql, "SQL query must not be null");
         Assert.requireNonNull(binding, "Binding query must not be null");
 
-        this.preparedStatements.put(createKey(sql, binding), handle);
+        this.preparedStatements.put(createKey(connectionKey, sql, binding), handle);
     }
 
     @SuppressWarnings("unchecked")
@@ -62,8 +64,8 @@ class IndefinitePreparedStatementCache implements PreparedStatementCache {
         return this.preparedStatements.size();
     }
 
-    private static String createKey(String sql, Binding binding) {
-        return sql + "-" + binding.getFormalParameters();
+    private static String createKey(Object connectionKey, String sql, Binding binding) {
+        return System.identityHashCode(connectionKey) + "-" + sql + "-" + binding.getFormalParameters();
     }
 
     @Override

--- a/src/main/java/io/r2dbc/mssql/PreparedStatementCache.java
+++ b/src/main/java/io/r2dbc/mssql/PreparedStatementCache.java
@@ -33,21 +33,23 @@ interface PreparedStatementCache {
     /**
      * Returns a prepared statement handle for the given {@code sql} query and the {@link Binding}.
      *
-     * @param sql     the SQL query.
-     * @param binding bound parameters. Parameter types impact the prepared query.
+     * @param connectionKey the connection key.
+     * @param sql           the SQL query.
+     * @param binding       bound parameters. Parameter types impact the prepared query.
      * @return the prepared statement handle. {@value 0} has a specific meaning as it indicates that no cached SQL statement was found.
      * @see #UNPREPARED
      */
-    int getHandle(String sql, Binding binding);
+    int getHandle(Object connectionKey, String sql, Binding binding);
 
     /**
      * Returns a prepared statement {@code handle} for the given {@code sql} query and the {@link Binding}.
      *
-     * @param handle  the prepared statement handle.
-     * @param sql     the SQL query.
-     * @param binding bound parameters. Parameter types impact the prepared query.
+     * @param connectionKey the connection key.
+     * @param handle        the prepared statement handle.
+     * @param sql           the SQL query.
+     * @param binding       bound parameters. Parameter types impact the prepared query.
      */
-    void putHandle(int handle, String sql, Binding binding);
+    void putHandle(Object connectionKey, int handle, String sql, Binding binding);
 
     /**
      * Returns the parsed and potentially cached representation of the {@code sql} statement.

--- a/src/test/java/io/r2dbc/mssql/ParametrizedMssqlStatementUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/ParametrizedMssqlStatementUnitTests.java
@@ -174,7 +174,7 @@ class ParametrizedMssqlStatementUnitTests {
 
         statement.execute().flatMap(MssqlResult::getRowsUpdated).subscribe();
 
-        assertThat(this.statementCache.getHandle(sql, binding)).isEqualTo(1);
+        assertThat(this.statementCache.getHandle(testClient, sql, binding)).isEqualTo(1);
     }
 
     @Test
@@ -200,11 +200,11 @@ class ParametrizedMssqlStatementUnitTests {
 
         Binding binding = statement.getBindings().getCurrent();
 
-        this.statementCache.putHandle(1, sql, binding);
+        this.statementCache.putHandle(testClient, 1, sql, binding);
 
         statement.execute().subscribe();
 
-        assertThat(this.statementCache.getHandle(sql, binding)).isEqualTo(1);
+        assertThat(this.statementCache.getHandle(testClient, sql, binding)).isEqualTo(1);
         assertThat(this.statementCache.size()).isEqualTo(1);
     }
 


### PR DESCRIPTION
Refactored PreparedStatementCache methods to include connection key parameter

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [✔️] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [✔️] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [✔️] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [✔️] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description
Issue #276 
<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context
The error is happening because of shared cache IndefinitePreparedStatementCache#preparedStatements. This cache is being used by all connection instances. Consider two similar queries where the difference is only in the number of parameters in the IN clause -

Query 1: IN (@p1) -> Expects 1 param.
Query 2: IN (@p1, @p2) -> Expects 2 params.

The IndefinitePreparedStatementCache is stored in ConnectionOptions. MssqlConnectionFactory creates a single ConnectionOptions instance and shares it across all connections it creates. Result: The PreparedStatementCache is shared globally. However, SQL Server prepared statement handles (returned by sp_cursorprepexec) are session-scoped (connection-local).

Connection A gets Handle 1 for Query 1.
Connection B gets Handle 1 for Query 2.
Connection A tries to execute Query 2. It finds Handle 1 (from Connection B's prepare) in the shared cache.
Connection A executes Handle 1. On Connection A, Handle 1 is Query 1.
Connection A provides 2 parameters. Query 1 expects 1.
Error: "Too many parameters".

The key in the shared cache is formed by the combination of the sql and its parameters. I have added the connection id as part of the key, so it is impossible to encounter a conflict of key across different connection. **The cache still remains shared**
<!-- Add any other context about the problem here. Do not add code as screenshots. -->
