### PR TITLE
Allow decoding of SMALLMONEY type in MoneyCodec

### DIFF
--- a/src/main/java/io/r2dbc/mssql/codec/MoneyCodec.java
+++ b/src/main/java/io/r2dbc/mssql/codec/MoneyCodec.java
@@ -84,7 +84,7 @@ final class MoneyCodec extends AbstractCodec<BigDecimal> {
 
     @Override
     boolean doCanDecode(TypeInformation typeInformation) {
-        return typeInformation.getServerType() == SqlServerType.MONEY;
+        return typeInformation.getServerType() == SqlServerType.MONEY || typeInformation.getServerType() == SqlServerType.SMALLMONEY;
     }
 
     @Override


### PR DESCRIPTION
Fixing the bug to support smallMoney.

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? --> No

Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

<!-- A clear and concise description of the issue or link to a GitHub issue #.-->
Small money data types were not supported, which leads to the following error

"java.lang.IllegalArgumentException: Cannot decode value of type [java.lang.Object], name [price] server type [smallmoney]"
 
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

<!-- Add any other context about the problem here. Do not add code as screenshots. -->
