### PR TITLE
Configure SSL engines with peer address

### DIFF
--- a/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
@@ -492,7 +492,8 @@ public final class ReactorNettyClient implements Client {
                 if (tunnel.isSslEnabled()) {
                     logger.debug(connectionContext.getMessage("Enabling SSL tunnel"));
                     try {
-                        pipeline.addFirst("sslTunnel", createSslTunnelHandler(it.channel().alloc(), tunnel));
+                        pipeline.addFirst("sslTunnel", createSslTunnelHandler(it.channel().alloc(), tunnel,
+                            configuration.getHost(), configuration.getPort()));
                     } catch (GeneralSecurityException e) {
                         it.channel().close();
                         throw new IllegalStateException("Cannot configure SSL tunnel", e);
@@ -515,8 +516,8 @@ public final class ReactorNettyClient implements Client {
         return connection.map(it -> new ReactorNettyClient(it, tdsEncoder, connectionContext.withChannelId(it.channel().toString())));
     }
 
-    private static SslHandler createSslTunnelHandler(ByteBufAllocator allocator, SslConfiguration tunnel) throws GeneralSecurityException {
-        return new SslHandler(tunnel.getSslContext().newEngine(allocator));
+    static SslHandler createSslTunnelHandler(ByteBufAllocator allocator, SslConfiguration tunnel, String host, int port) throws GeneralSecurityException {
+        return new SslHandler(tunnel.getSslContext().newEngine(allocator, host, port));
     }
 
     @Override

--- a/src/main/java/io/r2dbc/mssql/client/ssl/TdsSslHandler.java
+++ b/src/main/java/io/r2dbc/mssql/client/ssl/TdsSslHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.ssl.SslHandler;
+import io.r2dbc.mssql.client.ClientConfiguration;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.client.ConnectionState;
 import io.r2dbc.mssql.client.TdsEncoder;
@@ -65,7 +66,7 @@ public final class TdsSslHandler extends ChannelDuplexHandler {
 
     private final PacketIdProvider packetIdProvider;
 
-    private final SslConfiguration sslConfiguration;
+    private final ClientConfiguration clientConfiguration;
 
     private volatile SslHandler sslHandler;
 
@@ -84,17 +85,17 @@ public final class TdsSslHandler extends ChannelDuplexHandler {
      * Creates a new {@link TdsSslHandler}.
      *
      * @param packetIdProvider the {@link PacketIdProvider} to create {@link Header}s to wrap the SSL handshake.
-     * @param sslConfiguration SSL config.
+     * @param clientConfiguration client config.
      * @param context          Value object capturing diagnostic connection context.
      */
-    public TdsSslHandler(PacketIdProvider packetIdProvider, SslConfiguration sslConfiguration, ConnectionContext context) {
+    public TdsSslHandler(PacketIdProvider packetIdProvider, ClientConfiguration clientConfiguration, ConnectionContext context) {
 
         Assert.requireNonNull(packetIdProvider, "PacketIdProvider must not be null");
-        Assert.requireNonNull(sslConfiguration, "SslConfiguration must not be null");
+        Assert.requireNonNull(clientConfiguration, "ClientConfiguration must not be null");
         Assert.requireNonNull(context, "ConnectionContext must not be null");
 
         this.packetIdProvider = packetIdProvider;
-        this.sslConfiguration = sslConfiguration;
+        this.clientConfiguration = clientConfiguration;
         this.connectionContext = context;
     }
 
@@ -109,14 +110,14 @@ public final class TdsSslHandler extends ChannelDuplexHandler {
     /**
      * Create the {@link SslHandler}.
      *
-     * @param sslConfiguration the SSL configuration.
+     * @param clientConfiguration the client configuration.
      * @return the configured {@link SslHandler}.
      * @throws GeneralSecurityException thrown on security API errors.
      */
-    private static SslHandler createSslHandler(SslConfiguration sslConfiguration, ByteBufAllocator allocator) throws GeneralSecurityException {
+    static SslHandler createSslHandler(ClientConfiguration clientConfiguration, ByteBufAllocator allocator) throws GeneralSecurityException {
 
-        SSLEngine sslEngine = sslConfiguration.getSslContext()
-            .newEngine(allocator);
+        SSLEngine sslEngine = clientConfiguration.getSslContext()
+            .newEngine(allocator, clientConfiguration.getHost(), clientConfiguration.getPort());
 
         return new SslHandler(sslEngine);
     }
@@ -134,7 +135,7 @@ public final class TdsSslHandler extends ChannelDuplexHandler {
         if (evt == SslState.LOGIN_ONLY || evt == SslState.CONNECTION) {
 
             this.state = (SslState) evt;
-            this.sslHandler = createSslHandler(this.sslConfiguration, ctx.alloc());
+            this.sslHandler = createSslHandler(this.clientConfiguration, ctx.alloc());
 
             LOGGER.debug(this.connectionContext.getMessage("Registering Context Proxy and SSL Event Handlers to propagate SSL events to channelRead()"));
             ctx.pipeline().addAfter(getClass().getName(), ContextProxy.class.getName(), new ContextProxy());

--- a/src/test/java/io/r2dbc/mssql/client/ReactorNettyClientUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/ReactorNettyClientUnitTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.client;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.r2dbc.mssql.client.ssl.SslConfiguration;
+import io.r2dbc.mssql.util.TestByteBufAllocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ReactorNettyClient}.
+ */
+class ReactorNettyClientUnitTests {
+
+    @Test
+    void createSslTunnelHandlerConfiguresPeerHostAndPort() throws Exception {
+
+        SslHandler sslHandler = ReactorNettyClient.createSslTunnelHandler(TestByteBufAllocator.TEST, sslConfiguration(SslContextBuilder.forClient().build()), "localhost", 1433);
+
+        assertThat(sslHandler.engine().getPeerHost()).isEqualTo("localhost");
+        assertThat(sslHandler.engine().getPeerPort()).isEqualTo(1433);
+    }
+
+    private static SslConfiguration sslConfiguration(SslContext sslContext) {
+
+        return new SslConfiguration() {
+
+            @Override
+            public boolean isSslEnabled() {
+                return true;
+            }
+
+            @Override
+            public SslContext getSslContext() {
+                return sslContext;
+            }
+        };
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/client/ssl/TdsSslHandlerUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/ssl/TdsSslHandlerUnitTests.java
@@ -19,7 +19,9 @@ package io.r2dbc.mssql.client.ssl;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
+import io.r2dbc.mssql.client.ClientConfiguration;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.message.header.Header;
 import io.r2dbc.mssql.message.header.PacketIdProvider;
@@ -29,7 +31,9 @@ import io.r2dbc.mssql.util.TestByteBufAllocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import reactor.netty.resources.ConnectionProvider;
 
+import java.time.Duration;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,18 +48,53 @@ import static org.mockito.Mockito.verify;
  */
 class TdsSslHandlerUnitTests {
 
-    TdsSslHandler handler = new TdsSslHandler(PacketIdProvider.just(0), new SslConfiguration() {
+    TdsSslHandler handler = new TdsSslHandler(PacketIdProvider.just(0), clientConfiguration(null), new ConnectionContext());
 
-        @Override
-        public boolean isSslEnabled() {
-            return false;
-        }
+    private static ClientConfiguration clientConfiguration(SslContext sslContext) {
 
-        @Override
-        public SslContext getSslContext() {
-            return null;
-        }
-    }, new ConnectionContext());
+        return new ClientConfiguration() {
+
+            @Override
+            public String getHost() {
+                return "localhost";
+            }
+
+            @Override
+            public int getPort() {
+                return 1433;
+            }
+
+            @Override
+            public Duration getConnectTimeout() {
+                return Duration.ZERO;
+            }
+
+            @Override
+            public boolean isTcpKeepAlive() {
+                return false;
+            }
+
+            @Override
+            public boolean isTcpNoDelay() {
+                return true;
+            }
+
+            @Override
+            public ConnectionProvider getConnectionProvider() {
+                return ConnectionProvider.newConnection();
+            }
+
+            @Override
+            public boolean isSslEnabled() {
+                return sslContext != null;
+            }
+
+            @Override
+            public SslContext getSslContext() {
+                return sslContext;
+            }
+        };
+    }
 
     SslHandler sslHandler = mock(SslHandler.class);
 
@@ -67,6 +106,15 @@ class TdsSslHandlerUnitTests {
     void setUp() {
         this.handler.setSslHandler(this.sslHandler);
         this.handler.setState(SslState.CONNECTION);
+    }
+
+    @Test
+    void createSslHandlerConfiguresPeerHostAndPort() throws Exception {
+
+        SslHandler sslHandler = TdsSslHandler.createSslHandler(clientConfiguration(SslContextBuilder.forClient().build()), TestByteBufAllocator.TEST);
+
+        assertThat(sslHandler.engine().getPeerHost()).isEqualTo("localhost");
+        assertThat(sslHandler.engine().getPeerPort()).isEqualTo(1433);
     }
 
     @Test


### PR DESCRIPTION
Resolves #315.\n\nThis updates both SSL engine creation paths to pass the configured server host and port to Netty/JDK SSLEngine creation, avoiding endpoint identity checks with an undefined peer host.\n\nValidation:\n- ./mvnw -Dtest=io.r2dbc.mssql.client.ssl.TdsSslHandlerUnitTests,io.r2dbc.mssql.client.ReactorNettyClientUnitTests test\n- ./mvnw -DskipITs verify\n\nNote: integration tests are skipped with -DskipITs because they require a SQL Server/Testcontainers environment.