### PR TITLE
Skip deleted keyset-cursor placeholder rows (ROWSTAT=2)

### DIFF
--- a/src/main/java/io/r2dbc/mssql/CursorColumnLayout.java
+++ b/src/main/java/io/r2dbc/mssql/CursorColumnLayout.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.message.Message;
+import io.r2dbc.mssql.message.token.ColInfoToken;
+import io.r2dbc.mssql.message.token.Column;
+import io.r2dbc.mssql.message.token.ColumnMetadataToken;
+import io.r2dbc.mssql.message.token.RowToken;
+import io.r2dbc.mssql.message.type.Length;
+import io.r2dbc.mssql.message.type.SqlServerType;
+import io.r2dbc.mssql.message.type.TypeInformation;
+import io.r2dbc.mssql.util.Assert;
+import reactor.util.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Column layout of a server-cursor result. Server cursor fetches append a row status column ({@code ROWSTAT}) to each row. The server marks that column as hidden
+ * expression column through {@link ColInfoToken COLINFO}. A layout is only created for a verified row status column so that a user column that happens to be named
+ * {@code ROWSTAT} is never hidden and rows are never suppressed based on user data.
+ *
+ * @author dom54
+ * @see ColInfoToken
+ */
+final class CursorColumnLayout implements Message {
+
+    /**
+     * Name of the row status column synthesized by the server.
+     */
+    static final String ROW_STATUS_COLUMN_NAME = "ROWSTAT";
+
+    /**
+     * Row status for a row that was deleted after opening the cursor (keyset hole). Data columns do not contain values of the originally fetched row.
+     */
+    static final int ROW_STATUS_MISSING = 2;
+
+    private final ColumnMetadataToken metadata;
+
+    private final int rowStatusIndex;
+
+    private CursorColumnLayout(ColumnMetadataToken metadata, int rowStatusIndex) {
+        this.metadata = metadata;
+        this.rowStatusIndex = rowStatusIndex;
+    }
+
+    /**
+     * Create a {@link CursorColumnLayout} from {@link ColumnMetadataToken} and the {@link ColInfoToken} that describes the same columns. Returns {@code null} if the
+     * trailing column is not a verified hidden row status column.
+     *
+     * @param metadata the column metadata.
+     * @param colInfo  the column info.
+     * @return the {@link CursorColumnLayout} or {@code null} if the result does not contain a verified hidden row status column.
+     */
+    @Nullable
+    static CursorColumnLayout from(ColumnMetadataToken metadata, ColInfoToken colInfo) {
+
+        Assert.requireNonNull(metadata, "ColumnMetadataToken must not be null");
+        Assert.requireNonNull(colInfo, "ColInfoToken must not be null");
+
+        Column[] columns = metadata.getColumns();
+        List<ColInfoToken.ColInfo> infos = colInfo.getColumns();
+
+        if (columns.length == 0 || infos.size() != columns.length) {
+            return null;
+        }
+
+        int index = columns.length - 1;
+        Column column = columns[index];
+        ColInfoToken.ColInfo info = infos.get(index);
+
+        // COLINFO column numbers are one-based and encoded as single byte
+        if (Byte.toUnsignedInt(info.getColumn()) != ((index + 1) & 0xFF)) {
+            return null;
+        }
+
+        // the row status column is not derived from a base table
+        if (!info.isHidden() || !info.isExpression() || info.getTable() != 0) {
+            return null;
+        }
+
+        TypeInformation type = column.getType();
+        if (type.getServerType() != SqlServerType.INTEGER || !ROW_STATUS_COLUMN_NAME.equals(column.getName())) {
+            return null;
+        }
+
+        return new CursorColumnLayout(metadata, index);
+    }
+
+    /**
+     * @return the column metadata including the row status column.
+     */
+    ColumnMetadataToken getMetadata() {
+        return this.metadata;
+    }
+
+    /**
+     * @return the wire index of the row status column.
+     */
+    int getRowStatusIndex() {
+        return this.rowStatusIndex;
+    }
+
+    /**
+     * Returns whether the {@link RowToken} is a placeholder for a row that is missing (deleted since the cursor was opened).
+     *
+     * @param row the row.
+     * @return {@code true} if the row status indicates a missing row.
+     */
+    boolean isMissing(RowToken row) {
+
+        ByteBuf data = row.getColumnData(this.rowStatusIndex);
+
+        if (data == null) {
+            return false;
+        }
+
+        ByteBuf buffer = data.duplicate();
+        Length length = Length.decode(buffer, this.metadata.getColumns()[this.rowStatusIndex].getType());
+
+        if (length.isNull() || length.getLength() != 4 || buffer.readableBytes() < 4) {
+            return false;
+        }
+
+        return buffer.readIntLE() == ROW_STATUS_MISSING;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer();
+        sb.append(getClass().getSimpleName());
+        sb.append(" [metadata=").append(this.metadata);
+        sb.append(", rowStatusIndex=").append(this.rowStatusIndex);
+        sb.append(']');
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
+++ b/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
@@ -66,6 +66,9 @@ final class DefaultMssqlResult implements MssqlResult {
 
     private volatile MssqlRowMetadata rowMetadata;
 
+    // Full column metadata incl. the trailing cursor ROWSTAT column (used to skip deleted keyset rows).
+    private volatile ColumnMetadataToken columnMetadata;
+
     private DefaultMssqlResult(String sql, ConnectionContext context, Codecs codecs, Flux<io.r2dbc.mssql.message.Message> messages, boolean expectReturnValues) {
 
         this.sql = sql;
@@ -206,6 +209,7 @@ final class DefaultMssqlResult implements MssqlResult {
                         LOGGER.debug(this.context.getMessage("Result column definition: {}"), message);
                     }
 
+                    this.columnMetadata = token;
                     this.rowMetadata = MssqlRowMetadata.create(this.codecs, token);
 
                     return;
@@ -218,6 +222,13 @@ final class DefaultMssqlResult implements MssqlResult {
                     if (rowMetadata == null) {
                         ReferenceCountUtil.release(message);
                         sink.error(new IllegalStateException("No MssqlRowMetadata available"));
+                        return;
+                    }
+
+                    // Skip deleted/missing keyset-cursor placeholder rows (ROWSTAT=2); surfacing them
+                    // would yield a phantom all-null row that breaks non-null mapping.
+                    if (this.columnMetadata != null && RowToken.isDeletedCursorRow(this.columnMetadata, (RowToken) message)) {
+                        ((RowToken) message).release();
                         return;
                     }
 

--- a/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
+++ b/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
@@ -206,6 +206,11 @@ final class DefaultMssqlResult implements MssqlResult {
                     return;
                 }
 
+                if (message.getClass() == CursorColumnLayout.class) {
+                    this.rowMetadata = MssqlRowMetadata.create(this.codecs, (CursorColumnLayout) message);
+                    return;
+                }
+
                 if (rows && (message.getClass() == RowToken.class || message.getClass() == NbcRowToken.class)) {
 
                     MssqlRowMetadata rowMetadata = this.rowMetadata;

--- a/src/main/java/io/r2dbc/mssql/MssqlRowMetadata.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlRowMetadata.java
@@ -66,6 +66,26 @@ final class MssqlRowMetadata extends NamedCollectionSupport<Column> implements R
         return new MssqlRowMetadata(codecs, columnMetadata.getColumns(), columnMetadata.toMap());
     }
 
+    /**
+     * Creates a new {@link MssqlColumnMetadata} for a cursored result. The verified row status column of the {@link CursorColumnLayout} is not exposed.
+     *
+     * @param codecs the codec registry.
+     * @param layout the cursor column layout.
+     */
+    static MssqlRowMetadata create(Codecs codecs, CursorColumnLayout layout) {
+
+        Assert.notNull(layout, "CursorColumnLayout must not be null");
+
+        Column[] columns = layout.getMetadata().getColumns();
+        int rowStatusIndex = layout.getRowStatusIndex();
+
+        Column[] visible = new Column[columns.length - 1];
+        System.arraycopy(columns, 0, visible, 0, rowStatusIndex);
+        System.arraycopy(columns, rowStatusIndex + 1, visible, rowStatusIndex, columns.length - rowStatusIndex - 1);
+
+        return new MssqlRowMetadata(codecs, visible, toMap(visible, Column::getName));
+    }
+
     @Override
     public MssqlColumnMetadata getColumnMetadata(int index) {
         if (this.metadataCache == null) {

--- a/src/main/java/io/r2dbc/mssql/MssqlSegmentResult.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlSegmentResult.java
@@ -129,6 +129,8 @@ final class MssqlSegmentResult implements MssqlResult {
         }
 
         AtomicReference<MssqlRowMetadata> metadataRef = new AtomicReference<>();
+        // Full column metadata incl. the trailing cursor ROWSTAT column (used to skip deleted keyset rows).
+        AtomicReference<ColumnMetadataToken> columnMetadataRef = new AtomicReference<>();
         Flux<Segment> segments = messageStream.handle((message, sink) -> {
 
             if (message instanceof AbstractDoneToken) {
@@ -145,6 +147,7 @@ final class MssqlSegmentResult implements MssqlResult {
                 ColumnMetadataToken token = (ColumnMetadataToken) message;
 
                 if (token.hasColumns()) {
+                    columnMetadataRef.set(token);
                     metadataRef.set(MssqlRowMetadata.create(codecs, token));
                 }
                 return;
@@ -156,6 +159,14 @@ final class MssqlSegmentResult implements MssqlResult {
 
                 if (rowMetadata == null) {
                     ReferenceCountUtil.release(message);
+                    return;
+                }
+
+                // Skip deleted/missing keyset-cursor placeholder rows (ROWSTAT=2); surfacing them
+                // would yield a phantom all-null row that breaks non-null mapping.
+                ColumnMetadataToken columnMetadata = columnMetadataRef.get();
+                if (columnMetadata != null && RowToken.isDeletedCursorRow(columnMetadata, (RowToken) message)) {
+                    ((RowToken) message).release();
                     return;
                 }
 

--- a/src/main/java/io/r2dbc/mssql/MssqlSegmentResult.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlSegmentResult.java
@@ -140,6 +140,11 @@ final class MssqlSegmentResult implements MssqlResult {
                 return;
             }
 
+            if (message.getClass() == CursorColumnLayout.class) {
+                metadataRef.set(MssqlRowMetadata.create(codecs, (CursorColumnLayout) message));
+                return;
+            }
+
             if (message.getClass() == RowToken.class || message.getClass() == NbcRowToken.class) {
 
                 MssqlRowMetadata rowMetadata = metadataRef.get();

--- a/src/main/java/io/r2dbc/mssql/NamedCollectionSupport.java
+++ b/src/main/java/io/r2dbc/mssql/NamedCollectionSupport.java
@@ -40,23 +40,12 @@ abstract class NamedCollectionSupport<N> implements Collection<String> {
 
     private final String itemName;
 
-    @SuppressWarnings("unchecked")
     NamedCollectionSupport(N[] items, Map<String, N> nameKeyed, Function<N, String> nameMapper, String itemName) {
 
         this.nameMapper = nameMapper;
         this.itemName = itemName;
-
-        if (shouldStripROWSTAT(items)) {
-
-            this.items = (N[]) Array.newInstance(items.getClass().getComponentType(), items.length - 1);
-            System.arraycopy(items, 0, this.items, 0, this.items.length);
-
-            this.nameKeyed = toMap(this.items, nameMapper);
-        } else {
-
-            this.items = items;
-            this.nameKeyed = nameKeyed;
-        }
+        this.items = items;
+        this.nameKeyed = nameKeyed;
     }
 
     static <N> Map<String, N> toMap(N[] named, Function<N, String> nameMapper) {
@@ -71,11 +60,6 @@ abstract class NamedCollectionSupport<N> implements Collection<String> {
             }
         }
         return nameKeyed;
-    }
-
-    // Hide ROWSTAT column from metatada if it's the last column. Typically synthesized in cursored fetch.
-    private boolean shouldStripROWSTAT(N[] columns) {
-        return columns.length > 0 && "ROWSTAT".equals(this.nameMapper.apply(columns[columns.length - 1]));
     }
 
     /**

--- a/src/main/java/io/r2dbc/mssql/RpcQueryMessageFlow.java
+++ b/src/main/java/io/r2dbc/mssql/RpcQueryMessageFlow.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Sinks;
 import reactor.core.publisher.SynchronousSink;
 import reactor.util.Logger;
 import reactor.util.Loggers;
+import reactor.util.annotation.Nullable;
 
 import javax.annotation.processing.Completion;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,6 +57,7 @@ final class RpcQueryMessageFlow {
 
     private static final Predicate<Message> FILTER_PREDICATE = or(RowToken.class::isInstance,
         ColumnMetadataToken.class::isInstance,
+        CursorColumnLayout.class::isInstance,
         ReturnValue.class::isInstance,
         DoneInProcToken.class::isInstance,
         IntermediateCount.class::isInstance,
@@ -350,10 +352,30 @@ final class RpcQueryMessageFlow {
         handleMessage(client, fetchSize, t -> requests.emitNext(t, Sinks.EmitFailureHandler.FAIL_FAST), state, message, sink, onCursorComplete, emit);
     }
 
-    private static void handleMessage(Client client, int fetchSize, Consumer<ClientMessage> requests, CursorState state, Message message, SynchronousSink<Message> sink,
+    static void handleMessage(Client client, int fetchSize, Consumer<ClientMessage> requests, CursorState state, Message message, SynchronousSink<Message> sink,
                                       Runnable onCursorComplete, boolean emit) {
 
         if (message instanceof ColumnMetadataToken && !((ColumnMetadataToken) message).hasColumns()) {
+            return;
+        }
+
+        if (message instanceof ColumnMetadataToken) {
+            state.onColumnMetadata((ColumnMetadataToken) message);
+        }
+
+        if (message instanceof ColInfoToken) {
+
+            CursorColumnLayout layout = state.onColumnInfo((ColInfoToken) message);
+
+            if (layout != null && emit) {
+                sink.next(layout);
+            }
+            return;
+        }
+
+        // Missing rows (deleted after opening a keyset cursor) are placeholders without the original row data.
+        if (message instanceof RowToken && state.isMissing((RowToken) message)) {
+            ((RowToken) message).release();
             return;
         }
 
@@ -645,6 +667,14 @@ final class RpcQueryMessageFlow {
 
         volatile boolean directMode;
 
+        // column metadata of the current cursor result, awaiting COLINFO to verify the row status column
+        @Nullable
+        ColumnMetadataToken columns;
+
+        // verified layout of the current cursor result
+        @Nullable
+        CursorColumnLayout layout;
+
         Phase phase = Phase.NONE;
 
         /**
@@ -695,6 +725,46 @@ final class RpcQueryMessageFlow {
             if (it instanceof ErrorToken) {
                 this.hasSeenError = true;
             }
+        }
+
+        /**
+         * Retain column metadata of a cursor result. Resets a previously verified {@link CursorColumnLayout}.
+         *
+         * @param columns the column metadata.
+         */
+        void onColumnMetadata(ColumnMetadataToken columns) {
+            this.columns = columns;
+            this.layout = null;
+        }
+
+        /**
+         * Verify the row status column of the current cursor result using {@link ColInfoToken COLINFO}. Results executed directly (without a cursor) do not
+         * carry a row status column.
+         *
+         * @param colInfo the column info.
+         * @return the verified {@link CursorColumnLayout} or {@code null} if the result does not contain a hidden row status column.
+         */
+        @Nullable
+        CursorColumnLayout onColumnInfo(ColInfoToken colInfo) {
+
+            ColumnMetadataToken columns = this.columns;
+            this.columns = null;
+
+            if (this.directMode || columns == null) {
+                return null;
+            }
+
+            this.layout = CursorColumnLayout.from(columns, colInfo);
+            return this.layout;
+        }
+
+        /**
+         * @param row the row.
+         * @return {@code true} if the row is a placeholder for a row that was deleted after opening the cursor.
+         */
+        boolean isMissing(RowToken row) {
+            CursorColumnLayout layout = this.layout;
+            return layout != null && layout.isMissing(row);
         }
 
         public void update(Phase newPhase) {

--- a/src/main/java/io/r2dbc/mssql/message/token/ColInfoToken.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/ColInfoToken.java
@@ -130,7 +130,7 @@ public class ColInfoToken extends AbstractDataToken {
     /**
      * Column info for a column returned by a sp_cursor operation.
      */
-    static final class ColInfo {
+    public static final class ColInfo {
 
         /**
          * The column number in the result set.
@@ -177,6 +177,20 @@ public class ColInfoToken extends AbstractDataToken {
         @Nullable
         public String getName() {
             return this.name;
+        }
+
+        /**
+         * @return {@code true} if the column was not requested but added by the server (e.g. a cursor row status column or a browse-mode key column).
+         */
+        public boolean isHidden() {
+            return (this.status & STATUS_HIDDEN) != 0;
+        }
+
+        /**
+         * @return {@code true} if the column is the result of an expression and not derived from a base table column.
+         */
+        public boolean isExpression() {
+            return (this.status & STATUS_EXPRESSION) != 0;
         }
 
         @Override

--- a/src/main/java/io/r2dbc/mssql/message/token/RowToken.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/RowToken.java
@@ -23,6 +23,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.r2dbc.mssql.message.type.Length;
 import io.r2dbc.mssql.message.type.LengthStrategy;
 import io.r2dbc.mssql.message.type.PlpLength;
+import io.r2dbc.mssql.message.type.SqlServerType;
 import io.r2dbc.mssql.util.Assert;
 import reactor.util.annotation.Nullable;
 
@@ -49,6 +50,45 @@ public class RowToken extends AbstractReferenceCounted implements DataToken {
      */
     RowToken(ByteBuf[] data) {
         this.data = data;
+    }
+
+    private static final int ROWSTAT_DELETED = 2;
+
+    /**
+     * Determine whether a cursored fetch row is a placeholder for a row that is no longer in the result
+     * set (a keyset "hole": deleted/missing since the cursor was opened). SQL Server appends a trailing
+     * {@code ROWSTAT} column to cursor fetches; a value of {@code 2} means the row was deleted and the
+     * other columns are returned as NULL/default placeholders. Such rows must NOT be surfaced to the
+     * application — doing so yields a "phantom" all-null row. Returns {@code false} when the result has
+     * no trailing ROWSTAT column (non-cursored execution) or the row is valid.
+     *
+     * @param metadata the column metadata for the result (including the trailing ROWSTAT column).
+     * @param row      the decoded row.
+     * @return {@code true} if the row is a deleted/missing keyset placeholder and should be skipped.
+     */
+    public static boolean isDeletedCursorRow(ColumnMetadataToken metadata, RowToken row) {
+
+        Column[] columns = metadata.getColumns();
+        if (columns.length == 0) {
+            return false;
+        }
+
+        // The cursor row-status column is the synthesized trailing column named ROWSTAT, always an
+        // INT. Require both name AND integer type so a user column happening to be named ROWSTAT is
+        // never mistaken for it (which would wrongly drop a real row).
+        Column last = columns[columns.length - 1];
+        if (!"ROWSTAT".equals(last.getName()) || last.getType().getServerType() != SqlServerType.INTEGER) {
+            return false;
+        }
+
+        ByteBuf rowStat = row.getColumnData(columns.length - 1);
+        if (rowStat == null || rowStat.readableBytes() < 4) {
+            return false;
+        }
+
+        // ROWSTAT is a 4-byte little-endian int (the value is the last 4 bytes of the column data,
+        // whether or not a length prefix precedes it). 1 = row present; 2 = row deleted/missing.
+        return rowStat.getIntLE(rowStat.writerIndex() - 4) == ROWSTAT_DELETED;
     }
 
     /**

--- a/src/test/java/io/r2dbc/mssql/CursorColumnLayoutUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/CursorColumnLayoutUnitTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.r2dbc.mssql.message.token.ColInfoToken;
+import io.r2dbc.mssql.message.token.Column;
+import io.r2dbc.mssql.message.token.ColumnMetadataToken;
+import io.r2dbc.mssql.message.token.NbcRowToken;
+import io.r2dbc.mssql.message.token.RowToken;
+import io.r2dbc.mssql.message.type.LengthStrategy;
+import io.r2dbc.mssql.message.type.SqlServerType;
+import io.r2dbc.mssql.message.type.TypeInformation;
+import io.r2dbc.mssql.util.HexUtils;
+import io.r2dbc.mssql.util.Types;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CursorColumnLayout}.
+ *
+ * @author dom54
+ */
+class CursorColumnLayoutUnitTests {
+
+    static final TypeInformation FIXED_INT = TypeInformation.builder().withMaxLength(4).withLengthStrategy(LengthStrategy.FIXEDLENTYPE).withServerType(SqlServerType.INTEGER).build();
+
+    // id (key column of table 1), name (table 1), ROWSTAT (hidden expression) as sent by SQL Server for a keyset cursor
+    static final String CURSOR_COLINFO = "09 00 01 01 08 02 01 00 03 00 14";
+
+    Column[] columns = {new Column(0, "id", Types.integer()), new Column(1, "name", Types.varchar(50)), new Column(2, "ROWSTAT", FIXED_INT)};
+
+    @Test
+    void shouldVerifyHiddenRowStatusColumn() {
+
+        CursorColumnLayout layout = CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo(CURSOR_COLINFO));
+
+        assertThat(layout).isNotNull();
+        assertThat(layout.getRowStatusIndex()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldDetectMissingRow() {
+
+        CursorColumnLayout layout = CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo(CURSOR_COLINFO));
+
+        RowToken present = RowToken.decode(HexUtils.decodeToByteBuf("04 01 00 00 00 01 00 61 01 00 00 00"), this.columns);
+        RowToken missing = RowToken.decode(HexUtils.decodeToByteBuf("04 01 00 00 00 FF FF 02 00 00 00"), this.columns);
+
+        assertThat(layout.isMissing(present)).isFalse();
+        assertThat(layout.isMissing(missing)).isTrue();
+
+        present.release();
+        missing.release();
+    }
+
+    @Test
+    void shouldConsiderNullRowStatusAsPresent() {
+
+        Column[] columns = {new Column(0, "id", Types.integer()), new Column(1, "ROWSTAT", Types.integer())};
+        CursorColumnLayout layout = CursorColumnLayout.from(ColumnMetadataToken.create(columns), colInfo("06 00 01 01 08 02 00 14"));
+
+        // null bitmap: ROWSTAT is null
+        NbcRowToken row = NbcRowToken.decode(HexUtils.decodeToByteBuf("02 04 01 00 00 00"), columns);
+
+        assertThat(layout.isMissing(row)).isFalse();
+
+        row.release();
+    }
+
+    @Test
+    void shouldNotVerifyUserColumnNamedRowstat() {
+
+        // not hidden: SELECT id, name, CAST(2 AS int) AS ROWSTAT without row status column
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo("09 00 01 01 08 02 01 00 03 00 04"))).isNull();
+
+        // hidden key column of a base table
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo("09 00 01 01 08 02 01 00 03 01 18"))).isNull();
+    }
+
+    @Test
+    void shouldNotVerifyWithoutMatchingColumnInfo() {
+
+        // COLINFO describes fewer columns
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo("06 00 01 01 08 02 00 14"))).isNull();
+
+        // COLINFO column number does not match the trailing column
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(this.columns), colInfo("09 00 01 01 08 02 01 00 02 00 14"))).isNull();
+    }
+
+    @Test
+    void shouldNotVerifyNonIntegerOrDifferentlyNamedColumn() {
+
+        Column[] varchar = {new Column(0, "id", Types.integer()), new Column(1, "name", Types.varchar(50)), new Column(2, "ROWSTAT", Types.varchar(50))};
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(varchar), colInfo(CURSOR_COLINFO))).isNull();
+
+        Column[] renamed = {new Column(0, "id", Types.integer()), new Column(1, "name", Types.varchar(50)), new Column(2, "status", FIXED_INT)};
+        assertThat(CursorColumnLayout.from(ColumnMetadataToken.create(renamed), colInfo(CURSOR_COLINFO))).isNull();
+    }
+
+    private static ColInfoToken colInfo(String hex) {
+        return ColInfoToken.decode(HexUtils.decodeToByteBuf(hex));
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
@@ -19,8 +19,15 @@ package io.r2dbc.mssql;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.codec.DefaultCodecs;
 import io.r2dbc.mssql.message.Message;
+import io.r2dbc.mssql.message.token.Column;
+import io.r2dbc.mssql.message.token.ColumnMetadataToken;
 import io.r2dbc.mssql.message.token.DoneToken;
 import io.r2dbc.mssql.message.token.ErrorToken;
+import io.r2dbc.mssql.message.token.NbcRowToken;
+import io.r2dbc.mssql.message.type.TypeInformation;
+import io.r2dbc.mssql.util.HexUtils;
+import io.r2dbc.mssql.util.Types;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
@@ -89,6 +96,40 @@ class MssqlResultUnitTests {
 
         abstract MssqlResult create(Flux<Message> messages);
 
+    }
+
+    @Test
+    void mapSkipsDeletedKeysetCursorRows() {
+
+        TypeInformation intType = Types.integer();
+        TypeInformation strType = Types.varchar(255);
+
+        // A keyset-cursor fetch carries a synthesized trailing ROWSTAT (INT) column.
+        Column[] columns = Arrays.asList(
+            new Column(0, "id", intType),
+            new Column(1, "first_name", strType),
+            new Column(2, "last_name", strType),
+            new Column(3, "other", strType),
+            new Column(4, "other2", strType),
+            new Column(5, "other3", strType),
+            new Column(6, "ROWSTAT", intType)).toArray(new Column[0]);
+
+        // Identical row layout; only the trailing ROWSTAT int differs.
+        // 0x01 = row present; 0x02 = row deleted/missing placeholder (data columns are NULL/default).
+        NbcRowToken present = NbcRowToken.decode(
+            HexUtils.decodeToByteBuf("D2 1C 04 01 00 00 00 01 00 61 02 00 78 61 04 01 00 00 00").skipBytes(1), columns);
+        NbcRowToken deleted = NbcRowToken.decode(
+            HexUtils.decodeToByteBuf("D2 1C 04 01 00 00 00 01 00 61 02 00 78 61 04 02 00 00 00").skipBytes(1), columns);
+
+        MssqlResult result = DefaultMssqlResult.toResult("", new ConnectionContext(), new DefaultCodecs(),
+            Flux.just(ColumnMetadataToken.create(columns), deleted, present), false);
+
+        // Only the present row may surface. The ROWSTAT=2 deleted placeholder must be skipped, not
+        // surfaced as a phantom row. On current code both rows surface and this fails.
+        result.map((row, metadata) -> "row")
+            .as(StepVerifier::create)
+            .expectNext("row")
+            .verifyComplete();
     }
 
 }

--- a/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
@@ -20,9 +20,14 @@ import io.netty.buffer.ByteBuf;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.codec.DefaultCodecs;
 import io.r2dbc.mssql.message.Message;
+import io.r2dbc.mssql.message.token.ColInfoToken;
+import io.r2dbc.mssql.message.token.Column;
+import io.r2dbc.mssql.message.token.ColumnMetadataToken;
 import io.r2dbc.mssql.message.token.DoneToken;
 import io.r2dbc.mssql.message.token.ErrorToken;
 import io.r2dbc.mssql.message.token.ReturnValue;
+import io.r2dbc.mssql.message.token.RowToken;
+import io.r2dbc.mssql.util.HexUtils;
 import io.r2dbc.mssql.util.TestByteBufAllocator;
 import io.r2dbc.mssql.util.Types;
 import org.junit.jupiter.api.Test;
@@ -113,6 +118,39 @@ class MssqlResultUnitTests {
 
         abstract MssqlResult create(Flux<Message> messages);
 
+    }
+
+    @ParameterizedTest
+    @MethodSource("factories")
+    void shouldRetainUserColumnNamedRowstat(ResultFactory factory) {
+
+        // SELECT CAST(2 AS int) AS ROWSTAT: no cursor layout, the column is user data.
+        Column[] columns = {new Column(0, "ROWSTAT", Types.integer())};
+        RowToken row = RowToken.decode(HexUtils.decodeToByteBuf("04 02 00 00 00"), columns);
+
+        MssqlResult result = factory.create(Flux.just(ColumnMetadataToken.create(columns), row, DoneToken.create(1)));
+
+        Flux.from(result.map((r, metadata) -> metadata.getColumnMetadatas().size() + ":" + r.get("ROWSTAT", Integer.class)))
+            .as(StepVerifier::create)
+            .expectNext("1:2")
+            .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @MethodSource("factories")
+    void shouldHideVerifiedCursorRowStatusColumn(ResultFactory factory) {
+
+        Column[] columns = {new Column(0, "id", Types.integer()), new Column(1, "ROWSTAT", Types.integer())};
+        ColumnMetadataToken metadata = ColumnMetadataToken.create(columns);
+        CursorColumnLayout layout = CursorColumnLayout.from(metadata, ColInfoToken.decode(HexUtils.decodeToByteBuf("06 00 01 01 08 02 00 14")));
+        RowToken row = RowToken.decode(HexUtils.decodeToByteBuf("04 2A 00 00 00 04 01 00 00 00"), columns);
+
+        MssqlResult result = factory.create(Flux.just(metadata, layout, row, DoneToken.create(1)));
+
+        Flux.from(result.map((r, rowMetadata) -> rowMetadata.getColumnMetadatas().size() + ":" + rowMetadata.contains("ROWSTAT") + ":" + r.get("id", Integer.class)))
+            .as(StepVerifier::create)
+            .expectNext("1:false:42")
+            .verifyComplete();
     }
 
 }

--- a/src/test/java/io/r2dbc/mssql/MssqlRowMetadataUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlRowMetadataUnitTests.java
@@ -20,10 +20,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.r2dbc.mssql.codec.Codecs;
 import io.r2dbc.mssql.codec.DefaultCodecs;
+import io.r2dbc.mssql.message.token.ColInfoToken;
 import io.r2dbc.mssql.message.token.Column;
+import io.r2dbc.mssql.message.token.ColumnMetadataToken;
 import io.r2dbc.mssql.message.type.LengthStrategy;
 import io.r2dbc.mssql.message.type.SqlServerType;
 import io.r2dbc.mssql.message.type.TypeInformation;
+import io.r2dbc.mssql.util.HexUtils;
 import io.r2dbc.spi.Nullability;
 import org.junit.jupiter.api.Test;
 
@@ -68,19 +71,31 @@ class MssqlRowMetadataUnitTests {
     }
 
     @Test
-    void shouldRemoveRowstatIfLastColumn() {
+    void retainsRowstatIfLastColumn() {
 
-        Column rowstat = new Column(0, "ROWSTAT", this.integer, null);
+        Column rowstat = new Column(1, "ROWSTAT", this.integer, null);
+        Map<String, Column> nameKeyedColumns = new HashMap<>();
+        nameKeyedColumns.put("foo", this.column);
+        nameKeyedColumns.put("ROWSTAT", rowstat);
 
-        MssqlRowMetadata rowMetadata1 = new MssqlRowMetadata(this.codecs, new Column[]{this.column, rowstat}, new HashMap<>());
+        MssqlRowMetadata rowMetadata = new MssqlRowMetadata(this.codecs, new Column[]{this.column, rowstat}, nameKeyedColumns);
 
-        assertThat(rowMetadata1.getCount()).isOne();
-        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> rowMetadata1.getColumnMetadata("ROWSTAT"));
+        assertThat(rowMetadata.getCount()).isEqualTo(2);
+        assertThat(rowMetadata.getColumnMetadata("ROWSTAT").getName()).isEqualTo("ROWSTAT");
+    }
 
-        MssqlRowMetadata rowMetadata2 = new MssqlRowMetadata(this.codecs, new Column[]{rowstat}, new HashMap<>());
+    @Test
+    void shouldRemoveVerifiedCursorRowStatusColumn() {
 
-        assertThat(rowMetadata2.getCount()).isZero();
-        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> rowMetadata2.getColumnMetadata("ROWSTAT"));
+        Column rowstat = new Column(1, "ROWSTAT", this.integer, null);
+        ColumnMetadataToken metadata = ColumnMetadataToken.create(new Column[]{this.column, rowstat});
+        CursorColumnLayout layout = CursorColumnLayout.from(metadata, ColInfoToken.decode(HexUtils.decodeToByteBuf("06 00 01 01 08 02 00 14")));
+
+        MssqlRowMetadata rowMetadata = MssqlRowMetadata.create(this.codecs, layout);
+
+        assertThat(rowMetadata.getCount()).isOne();
+        assertThat(rowMetadata.getColumnMetadata("foo").getName()).isEqualTo("foo");
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> rowMetadata.getColumnMetadata("ROWSTAT"));
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/RpcQueryMessageFlowUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/RpcQueryMessageFlowUnitTests.java
@@ -30,9 +30,13 @@ import io.r2dbc.mssql.message.header.Status;
 import io.r2dbc.mssql.message.header.Type;
 import io.r2dbc.mssql.message.token.*;
 import io.r2dbc.mssql.message.type.Collation;
+import io.r2dbc.mssql.message.type.LengthStrategy;
+import io.r2dbc.mssql.message.type.SqlServerType;
+import io.r2dbc.mssql.message.type.TypeInformation;
 import io.r2dbc.mssql.util.ClientMessageAssert;
 import io.r2dbc.mssql.util.HexUtils;
 import io.r2dbc.mssql.util.TestByteBufAllocator;
+import io.r2dbc.mssql.util.Types;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Sinks;
@@ -348,6 +352,72 @@ class RpcQueryMessageFlowUnitTests {
         assertThat(state.phase).isEqualTo(CursorState.Phase.CLOSED);
         verifyNoInteractions(this.requests);
         verify(this.completion).run();
+    }
+
+    @Test
+    void shouldSuppressMissingRowsOfVerifiedCursorLayout() {
+
+        CursorState state = new CursorState();
+        Column[] columns = {new Column(0, "id", Types.integer()), new Column(1, "ROWSTAT", fixedInteger())};
+        ColumnMetadataToken metadata = ColumnMetadataToken.create(columns);
+
+        handleMessage(state, metadata);
+        verify(this.sink).next(metadata);
+
+        handleMessage(state, ColInfoToken.decode(HexUtils.decodeToByteBuf("06 00 01 01 08 02 00 14")));
+        verify(this.sink).next(any(CursorColumnLayout.class));
+
+        RowToken present = RowToken.decode(HexUtils.decodeToByteBuf("04 2A 00 00 00 01 00 00 00"), columns);
+        RowToken missing = RowToken.decode(HexUtils.decodeToByteBuf("04 2B 00 00 00 02 00 00 00"), columns);
+
+        handleMessage(state, present);
+        handleMessage(state, missing);
+
+        verify(this.sink).next(present);
+        verify(this.sink, never()).next(missing);
+        assertThat(missing.refCnt()).isZero();
+        verifyNoMoreInteractions(this.sink);
+    }
+
+    @Test
+    void shouldNotSuppressRowsWithoutVerifiedCursorLayout() {
+
+        // SELECT CAST(2 AS int) AS ROWSTAT
+        CursorState state = new CursorState();
+        Column[] columns = {new Column(0, "ROWSTAT", fixedInteger())};
+        RowToken row = RowToken.decode(HexUtils.decodeToByteBuf("02 00 00 00"), columns);
+
+        handleMessage(state, ColumnMetadataToken.create(columns));
+        handleMessage(state, row);
+
+        verify(this.sink).next(row);
+        verify(this.sink, never()).next(any(CursorColumnLayout.class));
+        assertThat(row.refCnt()).isOne();
+    }
+
+    @Test
+    void shouldNotVerifyCursorLayoutInDirectMode() {
+
+        CursorState state = new CursorState();
+        state.directMode = true;
+        Column[] columns = {new Column(0, "id", Types.integer()), new Column(1, "ROWSTAT", fixedInteger())};
+        RowToken row = RowToken.decode(HexUtils.decodeToByteBuf("04 2B 00 00 00 02 00 00 00"), columns);
+
+        handleMessage(state, ColumnMetadataToken.create(columns));
+        handleMessage(state, ColInfoToken.decode(HexUtils.decodeToByteBuf("06 00 01 01 08 02 00 14")));
+        handleMessage(state, row);
+
+        verify(this.sink, never()).next(any(CursorColumnLayout.class));
+        verify(this.sink).next(row);
+    }
+
+    private void handleMessage(CursorState state, Message message) {
+        state.update(message);
+        RpcQueryMessageFlow.handleMessage(this.client, 128, this.requests::tryEmitNext, state, message, this.sink, this.completion, true);
+    }
+
+    private static TypeInformation fixedInteger() {
+        return TypeInformation.builder().withMaxLength(4).withLengthStrategy(LengthStrategy.FIXEDLENTYPE).withServerType(SqlServerType.INTEGER).build();
     }
 
     private static DoneToken attentionAck() {

--- a/src/test/java/io/r2dbc/mssql/SimpleMssqlStatementIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/SimpleMssqlStatementIntegrationTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,6 +76,79 @@ class SimpleMssqlStatementIntegrationTests extends IntegrationTestSupport {
         connection.createStatement("SELECT 1").execute().flatMap(it -> it.map(row -> row.get(0))).as(StepVerifier::create).expectNext(1).expectComplete().verify(Duration.ofSeconds(5));
 
         connection.createStatement("DROP TABLE cursor_error").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+    }
+
+    @Test
+    void shouldNotEmitRowsDeletedAfterOpeningKeysetCursor() {
+
+        connection.createStatement("DROP TABLE IF EXISTS cursor_rowstat_deleted").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+        connection.createStatement("CREATE TABLE cursor_rowstat_deleted (id int PRIMARY KEY, name varchar(20) NOT NULL)").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+        connection.createStatement("INSERT INTO cursor_rowstat_deleted SELECT TOP 100 n, CONCAT('name-', 1000 - n) FROM (SELECT ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS n FROM sys.all_columns) numbers")
+            .execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).expectNext(100L).verifyComplete();
+
+        MssqlConnection other = connectionFactory.create().block();
+        AtomicBoolean deleted = new AtomicBoolean();
+
+        try {
+
+            // ORDER BY a non-indexed column turns the cursor into a keyset cursor. id = 1 is fetched last, after it was deleted by the other connection.
+            connection.createStatement("SELECT id, name FROM cursor_rowstat_deleted ORDER BY name").fetchSize(1).execute()
+                .flatMap(it -> it.map((row, metadata) -> {
+
+                    if (deleted.compareAndSet(false, true)) {
+                        other.createStatement("DELETE FROM cursor_rowstat_deleted WHERE id = 1").execute().flatMap(Result::getRowsUpdated).subscribe();
+                    }
+
+                    assertThat(metadata.getColumnMetadatas()).hasSize(2);
+                    return row.get("name", String.class);
+                }))
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(names -> assertThat(names).hasSize(99).doesNotContainNull().doesNotContain("name-999"))
+                .verifyComplete();
+        } finally {
+            other.close().block();
+        }
+
+        connection.createStatement("DROP TABLE cursor_rowstat_deleted").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+    }
+
+    @Test
+    void shouldRetainUserColumnNamedRowstat() {
+
+        for (int fetchSize : new int[]{0, 10}) {
+
+            connection.createStatement("SELECT CAST(2 AS int) AS ROWSTAT").fetchSize(fetchSize).execute()
+                .flatMap(it -> it.map((row, metadata) -> metadata.getColumnMetadata(0).getName() + "=" + row.get("ROWSTAT", Integer.class)))
+                .as(StepVerifier::create)
+                .expectNext("ROWSTAT=2")
+                .verifyComplete();
+        }
+
+        connection.createStatement("DROP TABLE IF EXISTS cursor_rowstat_user").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+        connection.createStatement("CREATE TABLE cursor_rowstat_user (id int PRIMARY KEY, ROWSTAT int)").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
+        connection.createStatement("INSERT INTO cursor_rowstat_user VALUES (1, 2), (2, 1)").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).expectNext(2L).verifyComplete();
+
+        for (int fetchSize : new int[]{0, 1}) {
+
+            connection.createStatement("SELECT id, ROWSTAT FROM cursor_rowstat_user ORDER BY ROWSTAT DESC").fetchSize(fetchSize).execute()
+                .flatMap(it -> it.map((row, metadata) -> metadata.getColumnMetadatas().size() + ":" + row.get("id", Integer.class) + "=" + row.get("ROWSTAT", Integer.class)))
+                .as(StepVerifier::create)
+                .expectNext("2:1=2", "2:2=1")
+                .verifyComplete();
+        }
+
+        // sp_cursorprepexec and sp_cursorexecute (cached prepared statement)
+        for (int i = 0; i < 2; i++) {
+
+            connection.createStatement("SELECT id, ROWSTAT FROM cursor_rowstat_user WHERE id > @id ORDER BY ROWSTAT DESC").bind("@id", 0).fetchSize(1).execute()
+                .flatMap(it -> it.map((row, metadata) -> metadata.getColumnMetadatas().size() + ":" + row.get("id", Integer.class) + "=" + row.get("ROWSTAT", Integer.class)))
+                .as(StepVerifier::create)
+                .expectNext("2:1=2", "2:2=1")
+                .verifyComplete();
+        }
+
+        connection.createStatement("DROP TABLE cursor_rowstat_user").execute().flatMap(Result::getRowsUpdated).as(StepVerifier::create).verifyComplete();
     }
 
 }


### PR DESCRIPTION
Fixes #332.

A keyset-driven cursor fetch carries a synthesized trailing `ROWSTAT` column. A row deleted (and committed) by another session after the cursor opened comes back as a `ROWSTAT = 2` "deleted/missing" placeholder whose data columns are NULL/default. The driver hides the `ROWSTAT` column from `RowMetadata` but never filtered the deleted row, so it surfaced as a phantom all-null row — breaking non-null mapping and yielding a spurious extra row.

This adds `RowToken#isDeletedCursorRow(metadata, row)` and skips such rows when mapping in `DefaultMssqlResult` and `MssqlSegmentResult`. The check requires the trailing column to be **both** named `ROWSTAT` **and** of `INTEGER` server type, so a user column merely named `ROWSTAT` is never mistaken for the cursor row-status (which would wrongly drop a real row). Non-cursored execution has no trailing `ROWSTAT` column and is unaffected.

Includes a server-free unit test (`MssqlResultUnitTests#mapSkipsDeletedKeysetCursorRows`) that fails without the change (the deleted placeholder surfaces as a second row) and passes with it. Full unit suite green.
