### PR TITLE
Release unconsumed return values when mapping rows

### DIFF
--- a/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
+++ b/src/main/java/io/r2dbc/mssql/DefaultMssqlResult.java
@@ -237,6 +237,12 @@ final class DefaultMssqlResult implements MssqlResult {
                 }
 
                 if (this.expectReturnValues && message instanceof ReturnValue) {
+                    // The row-mapping path (outparameters = false) does not collect ReturnValues into
+                    // the returnValues list, so the doFinally cleanup below never sees them and a bare
+                    // return here would leak the retained ReturnValue. Release it. The outparameters =
+                    // true path filters ReturnValues out upstream (releasing them via
+                    // MssqlReturnValues#release), so they never reach this branch and are not freed twice.
+                    ReferenceCountUtil.release(message);
                     return;
                 }
 

--- a/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlResultUnitTests.java
@@ -16,11 +16,16 @@
 
 package io.r2dbc.mssql;
 
+import io.netty.buffer.ByteBuf;
 import io.r2dbc.mssql.client.ConnectionContext;
 import io.r2dbc.mssql.codec.DefaultCodecs;
 import io.r2dbc.mssql.message.Message;
 import io.r2dbc.mssql.message.token.DoneToken;
 import io.r2dbc.mssql.message.token.ErrorToken;
+import io.r2dbc.mssql.message.token.ReturnValue;
+import io.r2dbc.mssql.util.TestByteBufAllocator;
+import io.r2dbc.mssql.util.Types;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
@@ -28,6 +33,8 @@ import reactor.test.StepVerifier;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link DefaultMssqlResult}.
@@ -89,6 +96,27 @@ class MssqlResultUnitTests {
 
         abstract MssqlResult create(Flux<Message> messages);
 
+    }
+
+    @Test
+    void mapReleasesUnconsumedReturnValues() {
+
+        ByteBuf data = TestByteBufAllocator.TEST.buffer();
+        data.writeBytes(new byte[]{(byte) 0x4, 0x42, 0, 0, 0});
+        ReturnValue returnValue = new ReturnValue(6, "@out", 0, Types.integer(), data);
+
+        // A result that expects return values but is consumed via map() (row mapping, i.e.
+        // outparameters = false) never collects the ReturnValue into the separate return-value
+        // stream. The ReturnValue therefore reaches the message handler, which must release it
+        // rather than dropping it with a bare return; otherwise its retained buffer leaks.
+        MssqlResult result = DefaultMssqlResult.toResult("", new ConnectionContext(), new DefaultCodecs(),
+            Flux.just(returnValue, DoneToken.create(0)), true);
+
+        result.map((row, metadata) -> row)
+            .as(StepVerifier::create)
+            .verifyComplete();
+
+        assertThat(returnValue.refCnt()).describedAs("ReturnValue released after an unconsumed map()").isZero();
     }
 
 }


### PR DESCRIPTION
Fixes #335.

When a result that expects return values (e.g. a stored-procedure / RPC call with output parameters) is consumed via `Result#map(...)`, the `ReturnValue` token was dropped without being released, leaking its retained direct `ByteBuf`.

`DefaultMssqlResult#doMap` collects and releases `ReturnValue`s only on the out-parameter path (`outparameters = true`). `map(...)` uses the row-mapping path (`outparameters = false`), where the handler dropped the `ReturnValue` with a bare `return`. This releases it there instead. The out-parameter path filters `ReturnValue`s out of the flux upstream (releasing them via `MssqlReturnValues#release`), so they never reach this branch — no double-free.

Includes a server-free unit test (`MssqlResultUnitTests#mapReleasesUnconsumedReturnValues`) that fails without the change (the `ReturnValue`'s refCnt stays non-zero after a completed `map()`) and passes with it. Full unit suite green.
