### PR TITLE
Release retained decoder state on connection close

### DIFF
--- a/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
+++ b/src/main/java/io/r2dbc/mssql/client/ReactorNettyClient.java
@@ -329,11 +329,15 @@ public final class ReactorNettyClient implements Client {
 
                 @Override
                 public void onError(Throwable t) {
+                    // Release any message the decoder was still aggregating across reads before terminating.
+                    decoder.dispose();
                     sink.error(t);
                 }
 
                 @Override
                 public void onComplete() {
+                    // Release any message the decoder was still aggregating across reads before terminating.
+                    decoder.dispose();
                     handleClose();
                 }
             });

--- a/src/main/java/io/r2dbc/mssql/client/StreamDecoder.java
+++ b/src/main/java/io/r2dbc/mssql/client/StreamDecoder.java
@@ -152,6 +152,20 @@ final class StreamDecoder {
     }
 
     /**
+     * Release any retained decoder state. Invoked when the inbound stream terminates (connection close or
+     * error) so that a message still being aggregated across reads does not leak its retained direct buffers.
+     */
+    void dispose() {
+
+        DecoderState state = this.state;
+        this.state = null;
+
+        if (state != null) {
+            state.release();
+        }
+    }
+
+    /**
      * The current decoding state. Encapsulates the raw transport stream buffers ("remainder") and the aggregated (de-chunked) body along an optional {@link Header}.
      */
     static class DecoderState {

--- a/src/test/java/io/r2dbc/mssql/client/StreamDecoderUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/StreamDecoderUnitTests.java
@@ -324,4 +324,34 @@ class StreamDecoderUnitTests {
 
         assertThat(decoder.decode(initialize, messageDecoder).get(0)).isInstanceOf(ColumnMetadataToken.class);
     }
+
+    @Test
+    void disposeReleasesRetainedDecoderState() {
+
+        StreamDecoder decoder = new StreamDecoder();
+
+        // Feed just the header type byte so the decoder retains a partial, not-yet-decodable message.
+        ByteBuf partial = Unpooled.wrappedBuffer(new byte[]{4});
+
+        List<Message> noMessage = decoder.decode(partial, ConnectionState.POST_LOGIN.decoder(CLIENT));
+        assertThat(noMessage).isEmpty();
+
+        StreamDecoder.DecoderState state = decoder.getDecoderState();
+        assertThat(state).isNotNull();
+
+        ByteBuf remainder = state.remainder;
+        ByteBuf aggregatedBody = state.aggregatedBody;
+        assertThat(remainder.refCnt()).isEqualTo(1);
+        assertThat(aggregatedBody.refCnt()).isEqualTo(1);
+
+        // On connection close the decoder may still hold a partial message; dispose() must release it.
+        decoder.dispose();
+
+        assertThat(decoder.getDecoderState()).isNull();
+        assertThat(remainder.refCnt()).isEqualTo(0);
+        assertThat(aggregatedBody.refCnt()).isEqualTo(0);
+
+        // Idempotent: a second dispose (e.g. onError following onComplete) must not throw.
+        decoder.dispose();
+    }
 }


### PR DESCRIPTION
Fixes #337.

`StreamDecoder` aggregates a TDS message that spans multiple inbound reads into a retained `DecoderState` (holding direct `ByteBuf`s), which is released only when message decoding fails. If the connection closes while a partial message is still buffered — a network drop, a server-side close, or pool eviction mid-read — the inbound stream terminates without releasing that state, leaking its direct buffers.

This adds `StreamDecoder#dispose()` to release any retained `DecoderState`, and calls it from the inbound terminal handlers (`onError` and `onComplete`) in `ReactorNettyClient`. Releasing on terminal is safe — a terminated inbound stream will not resume decoding.

Best-effort unit test (`StreamDecoderUnitTests#disposeReleasesRetainedDecoderState`): feed a partial message so the decoder retains state, then `dispose()` and assert the retained buffers are released and the state cleared, and that a second `dispose()` is idempotent. Full unit suite green. (The leak itself only manifests on a mid-message connection close, which has no dedicated unit harness; this test verifies the release hook the fix adds.)
