### PR TITLE
Serialise `PlpEncoded.ChunkSubscriber` aggregator access via the wip drain

### DIFF
--- a/src/main/java/io/r2dbc/mssql/codec/PlpEncoded.java
+++ b/src/main/java/io/r2dbc/mssql/codec/PlpEncoded.java
@@ -35,9 +35,10 @@ import reactor.core.publisher.Operators;
 import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import reactor.util.concurrent.Queues;
 import java.util.function.IntSupplier;
 
 /**
@@ -145,10 +146,6 @@ public class PlpEncoded extends Encoded {
 
     static class ChunkSubscriber extends AtomicLong implements CoreSubscriber<ByteBuf>, Subscription {
 
-        private static final int STATUS_WIP = 0;
-
-        private static final int STATUS_DONE = 1;
-
         private final CoreSubscriber<? super ByteBuf> actual;
 
         private final ByteBufAllocator allocator;
@@ -157,12 +154,21 @@ public class PlpEncoded extends Encoded {
 
         private final boolean withSizeHeaders;
 
+        // Incoming raw buffers are handed to the WIP-serialised drain() via this queue instead of being added
+        // to the aggregator directly from onNext. Together with the work-in-progress counter (this AtomicLong)
+        // this keeps every aggregator mutation/release on a single thread at a time, so a concurrent cancel()
+        // or onError() can never release the aggregator while onNext() is appending to it - without a lock.
+        private final Queue<ByteBuf> queue = Queues.<ByteBuf>unbounded().get();
+
         private boolean first = true;
 
         private volatile int nextChunkSize;
 
+        // Only accessed inside drain(), which the wip counter makes single-threaded at a time.
         @Nullable
-        private volatile CompositeByteBuf aggregator;
+        private CompositeByteBuf aggregator;
+
+        private boolean terminated;
 
         volatile long requested;
 
@@ -170,13 +176,12 @@ public class PlpEncoded extends Encoded {
         static final AtomicLongFieldUpdater<ChunkSubscriber> REQUESTED =
             AtomicLongFieldUpdater.newUpdater(ChunkSubscriber.class, "requested");
 
-        volatile int status;
+        private volatile boolean doneUpstream;
 
-        @SuppressWarnings("rawtypes")
-        static final AtomicIntegerFieldUpdater<ChunkSubscriber> STATUS =
-            AtomicIntegerFieldUpdater.newUpdater(ChunkSubscriber.class, "status");
+        @Nullable
+        private volatile Throwable error;
 
-        private boolean doneUpstream;
+        private volatile boolean cancelled;
 
         private Subscription s;
 
@@ -207,69 +212,112 @@ public class PlpEncoded extends Encoded {
 
             byteBuf.touch("PlpEncoded.onNext(…)");
 
-            if (STATUS.get(this) == STATUS_DONE) {
-
-                byteBuf.release();
-                Operators.onNextDropped(byteBuf, this.actual.currentContext());
-                return;
-            }
-
-            CompositeByteBuf aggregator = this.aggregator;
-            if (aggregator == null) {
-                this.aggregator = aggregator = this.allocator.compositeBuffer();
-            }
-
-            aggregator.addComponent(true, byteBuf);
+            // Hand the buffer to the serialised drain rather than mutating the aggregator here; drain()
+            // releases it if the subscription has already been cancelled or terminated.
+            this.queue.offer(byteBuf);
 
             drain();
 
-            if (!this.doneUpstream && REQUESTED.get(this) > 0) {
+            if (!this.doneUpstream && !this.cancelled && REQUESTED.get(this) > 0) {
                 this.s.request(1);
             }
         }
 
         private void drain() {
 
-            CompositeByteBuf aggregator = this.aggregator;
-
-            if (aggregator == null) {
-
-                if (this.doneUpstream && STATUS.compareAndSet(this, STATUS_WIP, STATUS_DONE)) {
-                    this.actual.onComplete();
-                }
-
+            if (getAndIncrement() != 0) {
                 return;
             }
 
-            while (STATUS.get(this) == STATUS_WIP && aggregator.readableBytes() >= this.nextChunkSize && REQUESTED.get(this) > 0) {
+            long missed = 1;
 
-                long demand = REQUESTED.get(this);
-                if (demand > 0) {
-                    if (REQUESTED.compareAndSet(this, demand, demand - 1)) {
-                        emitNext(aggregator, this.nextChunkSize);
-                        this.nextChunkSize = this.chunkSizeSupplier.getAsInt();
+            for (; ; ) {
+
+                if (this.cancelled) {
+                    discardAll();
+                } else if (this.error != null) {
+
+                    discardAll();
+                    if (!this.terminated) {
+                        this.terminated = true;
+                        this.actual.onError(this.error);
+                    }
+                } else {
+
+                    // Ingest queued raw buffers into the aggregator. This is the only place that appends,
+                    // and it runs single-threaded under the wip guard, so it never races a release below.
+                    ByteBuf next;
+                    while ((next = this.queue.poll()) != null) {
+
+                        CompositeByteBuf aggregator = this.aggregator;
+                        if (aggregator == null) {
+                            this.aggregator = aggregator = this.allocator.compositeBuffer();
+                        }
+                        aggregator.addComponent(true, next);
+                    }
+
+                    CompositeByteBuf aggregator = this.aggregator;
+
+                    if (aggregator != null) {
+
+                        while (!this.cancelled && aggregator.readableBytes() >= this.nextChunkSize && REQUESTED.get(this) > 0) {
+
+                            long demand = REQUESTED.get(this);
+                            if (demand > 0 && REQUESTED.compareAndSet(this, demand, demand - 1)) {
+                                emitNext(aggregator, this.nextChunkSize);
+                                this.nextChunkSize = this.chunkSizeSupplier.getAsInt();
+                            }
+                        }
+
+                        if (!this.cancelled && this.doneUpstream && aggregator.isReadable() && REQUESTED.get(this) > 0) {
+
+                            long demand = REQUESTED.get(this);
+                            if (demand > 0 && REQUESTED.compareAndSet(this, demand, demand - 1)) {
+                                emitNext(aggregator, aggregator.readableBytes());
+                            }
+                        }
+                    }
+
+                    // The !cancelled checks below are defensive: they preserve the "no onComplete after a
+                    // cancel" guarantee that the previous implementation got from a shared status CAS. Only a
+                    // tight concurrent interleaving (a cancel landing between the top-of-loop check and here)
+                    // could reach them, so they are not covered by a deterministic test.
+                    if (!this.cancelled && this.doneUpstream && this.queue.isEmpty() && (this.aggregator == null || !this.aggregator.isReadable())) {
+
+                        if (this.aggregator != null) {
+                            this.aggregator.release();
+                            this.aggregator = null;
+                        }
+
+                        if (!this.terminated) {
+                            this.terminated = true;
+                            this.actual.onComplete();
+                        }
+                    } else if (!this.cancelled && this.aggregator != null) {
+                        this.aggregator.discardReadComponents();
                     }
                 }
-            }
 
-            if (STATUS.get(this) == STATUS_WIP && this.doneUpstream && aggregator.isReadable() && REQUESTED.get(this) > 0) {
-
-                long demand = REQUESTED.get(this);
-                if (demand > 0) {
-                    if (REQUESTED.compareAndSet(this, demand, demand - 1)) {
-                        emitNext(aggregator, aggregator.readableBytes());
-                    }
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
                 }
             }
+        }
 
-            if (this.doneUpstream && !aggregator.isReadable() && STATUS.compareAndSet(this, STATUS_WIP, STATUS_DONE)) {
+        // Release everything we hold (queued-but-not-ingested buffers and the aggregator). Runs only inside
+        // the serialised drain, so it never races the ingest above.
+        private void discardAll() {
 
-                aggregator.release();
+            ByteBuf buf;
+            while ((buf = this.queue.poll()) != null) {
+                buf.release();
+            }
 
+            CompositeByteBuf aggregator = this.aggregator;
+            if (aggregator != null) {
                 this.aggregator = null;
-                this.actual.onComplete();
-            } else {
-                aggregator.discardReadComponents();
+                aggregator.release();
             }
         }
 
@@ -310,22 +358,9 @@ public class PlpEncoded extends Encoded {
         @Override
         public void onError(Throwable t) {
 
-            CompositeByteBuf aggregator = this.aggregator;
-
-            if (STATUS.compareAndSet(this, STATUS_WIP, STATUS_DONE)) {
-
-                this.doneUpstream = true;
-
-                this.actual.onError(t);
-
-                if (aggregator != null) {
-                    aggregator.release();
-                }
-
-                return;
-            }
-
-            Operators.onErrorDropped(t, this.actual.currentContext());
+            this.error = t;
+            this.doneUpstream = true;
+            drain();
         }
 
         @Override
@@ -345,7 +380,7 @@ public class PlpEncoded extends Encoded {
 
                 this.nextChunkSize = this.chunkSizeSupplier.getAsInt();
 
-                if (!this.doneUpstream && REQUESTED.get(this) > 0) {
+                if (!this.doneUpstream && !this.cancelled && REQUESTED.get(this) > 0) {
                     this.s.request(1);
                 }
             }
@@ -354,19 +389,13 @@ public class PlpEncoded extends Encoded {
         @Override
         public void cancel() {
 
-            if (!this.doneUpstream) {
-                this.doneUpstream = true;
+            this.cancelled = true;
+
+            if (this.s != null) {
                 this.s.cancel();
             }
 
-            if (STATUS.compareAndSet(this, STATUS_WIP, STATUS_DONE)) {
-
-                CompositeByteBuf aggregator = this.aggregator;
-
-                if (aggregator != null) {
-                    aggregator.release();
-                }
-            }
+            drain();
         }
 
     }

--- a/src/test/java/io/r2dbc/mssql/codec/PlpEncodedChunkSubscriberConcurrencyUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/codec/PlpEncodedChunkSubscriberConcurrencyUnitTests.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency regression test for {@link PlpEncoded.ChunkSubscriber}. Incoming chunks are appended to a
+ * {@code CompositeByteBuf} aggregator while {@code cancel}/{@code onError} release it. {@code onNext} hands its
+ * buffer to a work-in-progress-serialised drain that exclusively owns the aggregator, so an append can never run
+ * concurrently with a release. This test reproduces a &gt;5&nbsp;MB NVARCHAR(MAX)-sized stream fed on one thread
+ * while the subscription is cancelled on another: every fed component must end up released exactly once, with no
+ * {@code IllegalReferenceCountException} and no leak. Without the serialisation, a cancel that releases the
+ * aggregator mid-{@code addComponent} fails with {@code refCnt: 0} or leaks the component.
+ */
+class PlpEncodedChunkSubscriberConcurrencyUnitTests {
+
+    // ~5 MB of payload per iteration, fed as many components, to mirror a large NVARCHAR(MAX) bind and to
+    // widen the cancel-vs-onNext window so the race is hit reliably when the guard is absent.
+    private static final int COMPONENTS = 2000;
+
+    private static final int COMPONENT_SIZE = 2600; // 2000 * 2600 B = ~5 MiB
+
+    // Cancel once this many components are buffered: the aggregator is large, so its (component-by-component)
+    // release overlaps the in-flight onNext addComponent.
+    private static final int CANCEL_AFTER = 1000;
+
+    private static final Subscription NOOP_UPSTREAM = new Subscription() {
+        @Override
+        public void request(long n) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+    };
+
+    @RepeatedTest(200)
+    void cancelRacingOnNextNeitherLeaksNorDoubleFreesTheAggregator() throws Exception {
+
+        ByteBufAllocator allocator = PooledByteBufAllocator.DEFAULT;
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        try {
+            // Pre-allocate so the feeder thread spends ~all its time inside onNext (not allocating),
+            // which is what makes a mid-feed cancel actually overlap an in-flight addComponent.
+            List<ByteBuf> fed = new ArrayList<>(COMPONENTS);
+            for (int i = 0; i < COMPONENTS; i++) {
+                fed.add(allocator.buffer(COMPONENT_SIZE).writeZero(COMPONENT_SIZE));
+            }
+            AtomicInteger fedCount = new AtomicInteger();
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            // Stands in for the wire encoder: consumes (releases) any chunk that is emitted.
+            CoreSubscriber<ByteBuf> wire = new CoreSubscriber<ByteBuf>() {
+                @Override
+                public Context currentContext() {
+                    return Context.empty();
+                }
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                    // Do not request: leaving the chunks buffered in the aggregator widens the window in which
+                    // a concurrent cancel/release races onNext's addComponent.
+                }
+
+                @Override
+                public void onNext(ByteBuf chunk) {
+                    chunk.release();
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                }
+
+                @Override
+                public void onComplete() {
+                }
+            };
+
+            PlpEncoded.ChunkSubscriber subscriber = new PlpEncoded.ChunkSubscriber(wire, allocator, () -> COMPONENT_SIZE, false);
+            subscriber.onSubscribe(NOOP_UPSTREAM);
+
+            CyclicBarrier start = new CyclicBarrier(2);
+
+            Future<?> feeder = pool.submit(() -> {
+                awaitQuietly(start);
+                try {
+                    // Feed the whole (pre-allocated) stream. We do NOT call onComplete: a cancelled stream's
+                    // upstream is cancelled and never completes. Every fed buffer is still freed — drained to the
+                    // wire, or released by the serialised drain when it discards the queue/aggregator after cancel.
+                    for (ByteBuf component : fed) {
+                        fedCount.incrementAndGet();
+                        subscriber.onNext(component);
+                    }
+                } catch (Throwable t) {
+                    // e.g. IllegalReferenceCountException when the guard is removed (release raced addComponent).
+                    failure.compareAndSet(null, t);
+                }
+            });
+
+            Future<?> canceller = pool.submit(() -> {
+                awaitQuietly(start);
+                while (fedCount.get() < CANCEL_AFTER && failure.get() == null) {
+                    // busy-spin on the volatile counter until the aggregator is large
+                }
+                try {
+                    subscriber.cancel();
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            });
+
+            feeder.get(30, TimeUnit.SECONDS);
+            canceller.get(30, TimeUnit.SECONDS);
+
+            assertThat(failure.get()).describedAs("cancel raced onNext on the aggregator").isNull();
+
+            // Every fed component must end up released — either drained to the wire, or freed when the
+            // aggregator is released on cancel/complete. A non-zero refCnt is a leaked component (the
+            // race added it after the aggregator was released).
+            for (ByteBuf component : fed) {
+                assertThat(component.refCnt()).describedAs("component leaked: cancel raced onNext").isZero();
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // A downstream that cancels synchronously from its first onNext (like take(1)) must not receive any
+    // further onNext, and the buffered remainder must be released (no leak). Single-threaded and deterministic.
+    @Test
+    void doesNotEmitAfterDownstreamCancelsMidDrain() {
+
+        ByteBufAllocator allocator = PooledByteBufAllocator.DEFAULT;
+
+        AtomicInteger emitted = new AtomicInteger();
+        List<ByteBuf> received = new ArrayList<>();
+        AtomicReference<Subscription> downstreamSubscription = new AtomicReference<>();
+
+        CoreSubscriber<ByteBuf> cancelsOnFirst = new CoreSubscriber<ByteBuf>() {
+            @Override
+            public Context currentContext() {
+                return Context.empty();
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                downstreamSubscription.set(s);
+                s.request(5);
+            }
+
+            @Override
+            public void onNext(ByteBuf chunk) {
+                emitted.incrementAndGet();
+                received.add(chunk);
+                downstreamSubscription.get().cancel(); // cancel synchronously from within onNext
+            }
+
+            @Override
+            public void onError(Throwable t) {
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        };
+
+        // chunk size 10, feed 25 bytes -> two full chunks are available in a single drain.
+        PlpEncoded.ChunkSubscriber subscriber = new PlpEncoded.ChunkSubscriber(cancelsOnFirst, allocator, () -> 10, false);
+        subscriber.onSubscribe(NOOP_UPSTREAM);
+
+        ByteBuf data = allocator.buffer(25).writeZero(25);
+        subscriber.onNext(data);
+
+        try {
+            assertThat(emitted.get()).describedAs("must not emit another chunk after a synchronous cancel").isEqualTo(1);
+            assertThat(data.refCnt()).describedAs("buffered remainder released after cancel").isZero();
+        } finally {
+            received.forEach(buf -> {
+                if (buf.refCnt() > 0) {
+                    buf.release();
+                }
+            });
+        }
+    }
+
+    private static void awaitQuietly(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/codec/PlpEncodedChunkSubscriberConcurrencyUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/codec/PlpEncodedChunkSubscriberConcurrencyUnitTests.java
@@ -38,13 +38,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Concurrency regression test for {@link PlpEncoded.ChunkSubscriber}. Incoming chunks are appended to a
- * {@code CompositeByteBuf} aggregator while {@code cancel}/{@code onError} release it. {@code onNext} hands its
- * buffer to a work-in-progress-serialised drain that exclusively owns the aggregator, so an append can never run
- * concurrently with a release. This test reproduces a &gt;5&nbsp;MB NVARCHAR(MAX)-sized stream fed on one thread
- * while the subscription is cancelled on another: every fed component must end up released exactly once, with no
- * {@code IllegalReferenceCountException} and no leak. Without the serialisation, a cancel that releases the
- * aggregator mid-{@code addComponent} fails with {@code refCnt: 0} or leaks the component.
+ * Concurrency regression tests for {@link PlpEncoded.ChunkSubscriber}. {@code onNext} hands its buffer to a
+ * work-in-progress-serialised drain that exclusively owns the {@code CompositeByteBuf} aggregator, so the
+ * aggregator is never mutated/released by two threads at once. Both downstream signals can race {@code onNext}
+ * (upstream delivery): {@code cancel} (which releases the aggregator) and {@code request} (which drives a second
+ * concurrent {@code drain()}). On the unserialised code each fails ~50% of runs — a {@code cancel} releasing the
+ * aggregator mid-{@code addComponent} throws {@code refCnt: 0}, and a concurrent {@code request}/{@code onNext}
+ * drain corrupts the aggregator's reader/writer indices ({@code IndexOutOfBoundsException}) — or leaks a chunk.
+ * Both must instead release every fed component exactly once with no exception.
  */
 class PlpEncodedChunkSubscriberConcurrencyUnitTests {
 
@@ -215,6 +216,90 @@ class PlpEncodedChunkSubscriberConcurrencyUnitTests {
                     buf.release();
                 }
             });
+        }
+    }
+
+    // No cancel: request() (downstream demand) races onNext() (upstream delivery), driving two concurrent
+    // drain()s over the non-thread-safe CompositeByteBuf. On the unserialised code this fails ~50% of runs
+    // (refCnt: 0 / reader-writer index corruption), proving the defect is not specific to cancellation.
+    @RepeatedTest(200)
+    void requestRacingOnNextNeitherCorruptsNorLeaks() throws Exception {
+
+        ByteBufAllocator allocator = PooledByteBufAllocator.DEFAULT;
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        try {
+            List<ByteBuf> fed = new ArrayList<>(COMPONENTS);
+            for (int i = 0; i < COMPONENTS; i++) {
+                fed.add(allocator.buffer(COMPONENT_SIZE).writeZero(COMPONENT_SIZE));
+            }
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            CoreSubscriber<ByteBuf> wire = new CoreSubscriber<ByteBuf>() {
+                @Override
+                public Context currentContext() {
+                    return Context.empty();
+                }
+
+                @Override
+                public void onSubscribe(Subscription s) {
+                }
+
+                @Override
+                public void onNext(ByteBuf chunk) {
+                    chunk.release();
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+
+                @Override
+                public void onComplete() {
+                }
+            };
+
+            PlpEncoded.ChunkSubscriber subscriber = new PlpEncoded.ChunkSubscriber(wire, allocator, () -> COMPONENT_SIZE, false);
+            subscriber.onSubscribe(NOOP_UPSTREAM);
+
+            CyclicBarrier start = new CyclicBarrier(2);
+
+            Future<?> feeder = pool.submit(() -> {
+                awaitQuietly(start);
+                try {
+                    for (ByteBuf component : fed) {
+                        subscriber.onNext(component);
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            });
+
+            Future<?> requester = pool.submit(() -> {
+                awaitQuietly(start);
+                try {
+                    for (int i = 0; i < COMPONENTS; i++) {
+                        subscriber.request(1);
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            });
+
+            feeder.get(30, TimeUnit.SECONDS);
+            requester.get(30, TimeUnit.SECONDS);
+
+            // Drain any remainder and complete; every fed component must be released exactly once.
+            subscriber.request(Long.MAX_VALUE);
+            subscriber.onComplete();
+
+            assertThat(failure.get()).describedAs("request raced onNext on the aggregator (no cancel)").isNull();
+            for (ByteBuf component : fed) {
+                assertThat(component.refCnt()).describedAs("component leaked: request raced onNext").isZero();
+            }
+        } finally {
+            pool.shutdownNow();
         }
     }
 


### PR DESCRIPTION
Fixes #341.

`PlpEncoded.ChunkSubscriber` aggregated incoming chunks of a large PLP value into a `CompositeByteBuf` with no serialization between its methods: `onNext` appends (`addComponent`), `cancel`/`onError` release it, and `onNext`/`request` both run `drain()`. Concurrent access — most reliably a cancel racing `onNext` while a large `NVARCHAR(MAX)`/`VARBINARY(MAX)` value is still streaming (e.g. a statement timeout or downstream `take`/`timeout` cancelling on another thread) — released the aggregator under an in-flight `addComponent`, throwing `IllegalReferenceCountException` (use-after-free) or leaking a chunk.

This finishes the work-in-progress (WIP) serialization the class was already set up for (it `extends AtomicLong`): `onNext` enqueues its buffer and a single WIP-serialised `drain()` exclusively owns the aggregator (ingest/append, emit per demand, release on terminal/cancel). `cancel`/`onError`/`onComplete` just set a flag and `drain()`. No `synchronized` on the hot path; chunking and back-pressure behaviour are unchanged.

Tests:
- New `PlpEncodedChunkSubscriberConcurrencyUnitTests`: a ~5 MB stream fed on one thread while cancelled on another — fails ~50% of runs on the current code (`refCnt: 0`), 200/200 here. Plus a deterministic test that a synchronous downstream cancel mid-drain emits no further chunk (fails without the emit-loop guard).
- Existing `PlpEncodedUnitTests` (chunk splitting, PLP headers, dispose on complete/cancel/error, empty-no-alloc) unchanged and green; full unit suite + LOB/JSON integration green against MSSQL 2022.
