### PR TITLE
Add SQL Server named instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This driver provides the following features:
 * Complies with R2DBC 1.0
 * Login with username/password with temporary SSL encryption
 * Full SSL encryption support (for e.g. Azure usage).
+* SQL Server named instance discovery through SQL Server Browser (SSRP)
 * Transaction Control
 * Simple execution of SQL batches (direct and cursored execution)
 * Execution of parametrized statements (direct and cursored execution)
@@ -38,6 +39,10 @@ ConnectionFactory connectionFactory = ConnectionFactories.get("r2dbc:mssql://<ho
 Publisher<? extends Connection> connectionPublisher = connectionFactory.create();
 ```
 
+To discover the TCP port of a named SQL Server instance, specify `instanceName`
+and omit the port:
+`r2dbc:mssql://<host>/<database>?instanceName=SQLEXPRESS`.
+
 **Programmatic Connection Factory Discovery**
 
 ```java
@@ -45,6 +50,7 @@ ConnectionFactoryOptions options = builder()
     .option(DRIVER, "sqlserver")
     .option(HOST, "…")
     .option(PORT, …)  // optional, defaults to 1433
+    .option(MssqlConnectionFactoryProvider.INSTANCE_NAME, "SQLEXPRESS") // optional
     .option(USER, "…")
     .option(PASSWORD, "…")
     .option(DATABASE, "…") // optional
@@ -69,7 +75,8 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `ssl`                           | Whether to use transport-level encryption for the entire SQL server traffic.                                                                                                                                                                                              
 | `driver`                        | Must be `sqlserver`.                                                                                                                                                                                                                                                      
 | `host`                          | Server hostname to connect to.                                                                                                                                                                                                                                            
-| `port`                          | Server port to connect to. Defaults to `1433`. _(Optional)_                                                                                                                                                                                                               
+| `port`                          | Server port to connect to. Defaults to `1433` when no named instance is configured. If both `port` and `instanceName` are specified, the explicit port takes precedence. _(Optional)_
+| `instanceName`                  | SQL Server named instance. If no explicit port is configured, the driver resolves the TCP port through SQL Server Browser using SSRP over UDP port `1434`. _(Optional)_
 | `username`                      | Login username.                                                                                                                                                                                                                                                           
 | `password`                      | Login password.                                                                                                                                                                                                                                                           
 | `database`                      | Initial database to select. Defaults to SQL Server user profile settings. _(Optional)_                                                                                                                                                                                    
@@ -96,6 +103,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 ```java
 MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
     .host("…")
+    .instanceName("SQLEXPRESS") // optional
     .username("…")
     .password("…")
     .database("…")
@@ -106,6 +114,26 @@ MssqlConnectionFactory factory = new MssqlConnectionFactory(configuration);
 
 Mono<MssqlConnection> connectionMono = factory.create();
 ```
+
+### Named SQL Server Instances
+
+Named instances can use dynamic TCP ports. Configure the instance name with the
+`instanceName` option and omit `port` to let the driver discover the current TCP
+port through SQL Server Browser using the SQL Server Resolution Protocol (SSRP).
+
+The SQL Server Browser service must be running on the target host and UDP port
+`1434` must be reachable from the client.
+
+Connection target precedence is:
+
+* Host only: connect to the default TCP port `1433`.
+* Host and explicit `port`: connect to the configured port.
+* Host and `instanceName`: resolve the TCP port through SQL Server Browser.
+* Host, `instanceName`, and explicit `port`: the explicit port takes precedence
+  and SQL Server Browser discovery is skipped.
+
+SQL Server routing redirects use the server-provided host and port directly and
+do not trigger another named-instance lookup.
 
 Microsoft SQL Server uses named parameters that are prefixed with `@`. The following SQL statement makes use of parameters:
 

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
@@ -202,6 +202,14 @@ public final class MssqlConnectionConfiguration {
         );
     }
 
+    MssqlConnectionConfiguration withResolvedPort(int port) {
+        return new MssqlConnectionConfiguration(this.applicationName, this.connectionId, this.connectionProvider, this.connectTimeout, this.database, this.host, this.hostNameInCertificate,
+            this.instanceName, this.lockWaitTimeout,
+            this.password,
+            this.preferCursoredExecution, port, true, this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
+            this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay, this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword, this.username
+        );
+    }
     public ClientConfiguration toClientConfiguration() {
         return new DefaultClientConfiguration(this.connectionProvider, this.connectTimeout, this.host, this.hostNameInCertificate, this.port, this.ssl, this.sslContextBuilderCustomizer,
             this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay, this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
@@ -87,6 +87,9 @@ public final class MssqlConnectionConfiguration {
 
     private final String hostNameInCertificate;
 
+    @Nullable
+    private final String instanceName;
+
     private final CharSequence password;
 
     private final Predicate<String> preferCursoredExecution;
@@ -95,6 +98,8 @@ public final class MssqlConnectionConfiguration {
     private final Duration lockWaitTimeout;
 
     private final int port;
+
+    private final boolean portConfigured;
 
     private final boolean sendStringParametersAsUnicode;
 
@@ -124,8 +129,8 @@ public final class MssqlConnectionConfiguration {
 
     private MssqlConnectionConfiguration(@Nullable String applicationName, @Nullable UUID connectionId, ConnectionProvider connectionProvider,
                                          Duration connectTimeout, @Nullable String database, String host, String hostNameInCertificate,
-                                         @Nullable Duration lockWaitTimeout, CharSequence password, Predicate<String> preferCursoredExecution,
-                                         int port, boolean sendStringParametersAsUnicode, boolean ssl,
+                                         @Nullable String instanceName, @Nullable Duration lockWaitTimeout, CharSequence password, Predicate<String> preferCursoredExecution,
+                                         int port, boolean portConfigured, boolean sendStringParametersAsUnicode, boolean ssl,
                                          Function<SslContextBuilder, SslContextBuilder> sslContextBuilderCustomizer,
                                          @Nullable Function<SslContextBuilder, SslContextBuilder> sslTunnelSslContextBuilderCustomizer,
                                          boolean tcpKeepAlive, boolean tcpNoDelay, boolean trustServerCertificate, @Nullable File trustStore,
@@ -138,10 +143,12 @@ public final class MssqlConnectionConfiguration {
         this.database = database;
         this.host = Assert.requireNonNull(host, "host must not be null");
         this.hostNameInCertificate = Assert.requireNonNull(hostNameInCertificate, "hostNameInCertificate must not be null");
+        this.instanceName = instanceName;
         this.lockWaitTimeout = lockWaitTimeout;
         this.password = Assert.requireNonNull(password, "password must not be null");
         this.preferCursoredExecution = Assert.requireNonNull(preferCursoredExecution, "preferCursoredExecution must not be null");
         this.port = port;
+        this.portConfigured = portConfigured;
         this.sendStringParametersAsUnicode = sendStringParametersAsUnicode;
         this.ssl = ssl;
         this.sslContextBuilderCustomizer = sslContextBuilderCustomizer;
@@ -188,9 +195,9 @@ public final class MssqlConnectionConfiguration {
         }
 
         return new MssqlConnectionConfiguration(this.applicationName, this.connectionId, this.connectionProvider, this.connectTimeout, this.database, redirectServerName, hostNameInCertificate,
-            this.lockWaitTimeout,
+            null, this.lockWaitTimeout,
             this.password,
-            this.preferCursoredExecution, redirect.getPort(), this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
+            this.preferCursoredExecution, redirect.getPort(), true, this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
             this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay, this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword, this.username
         );
     }
@@ -215,10 +222,12 @@ public final class MssqlConnectionConfiguration {
         sb.append(", database=\"").append(this.database).append('\"');
         sb.append(", host=\"").append(this.host).append('\"');
         sb.append(", hostNameInCertificate=\"").append(this.hostNameInCertificate).append('\"');
+        sb.append(", instanceName=\"").append(this.instanceName).append('\"');
         sb.append(", lockWaitTimeout=\"").append(this.lockWaitTimeout).append('\"');
         sb.append(", password=\"").append(repeat(this.password.length(), "*")).append('\"');
         sb.append(", preferCursoredExecution=\"").append(this.preferCursoredExecution).append('\"');
         sb.append(", port=").append(this.port);
+        sb.append(", portConfigured=").append(this.portConfigured);
         sb.append(", sendStringParametersAsUnicode=").append(this.sendStringParametersAsUnicode);
         sb.append(", ssl=").append(this.ssl);
         sb.append(", sslContextBuilderCustomizer=").append(this.sslContextBuilderCustomizer);
@@ -260,6 +269,10 @@ public final class MssqlConnectionConfiguration {
         return this.hostNameInCertificate;
     }
 
+    Optional<String> getInstanceName() {
+        return Optional.ofNullable(this.instanceName);
+    }
+
     @Nullable
     Duration getLockWaitTimeout() {
         return this.lockWaitTimeout;
@@ -275,6 +288,10 @@ public final class MssqlConnectionConfiguration {
 
     int getPort() {
         return this.port;
+    }
+
+    boolean isPortConfigured() {
+        return this.portConfigured;
     }
 
     boolean isSendStringParametersAsUnicode() {
@@ -363,6 +380,9 @@ public final class MssqlConnectionConfiguration {
         private String hostNameInCertificate;
 
         @Nullable
+        private String instanceName;
+
+        @Nullable
         private Duration lockWaitTimeout;
 
         private Predicate<String> preferCursoredExecution = DefaultCursorPreference.INSTANCE;
@@ -370,6 +390,8 @@ public final class MssqlConnectionConfiguration {
         private CharSequence password;
 
         private int port = DEFAULT_PORT;
+
+        private boolean portConfigured;
 
         private boolean sendStringParametersAsUnicode = true;
 
@@ -524,6 +546,18 @@ public final class MssqlConnectionConfiguration {
             this.hostNameInCertificate = Assert.requireNonNull(hostNameInCertificate, "hostNameInCertificate must not be null");
             return this;
         }
+        /**
+         * Configure the SQL Server instance name.
+         *
+         * @param instanceName the SQL Server instance name
+         * @return this {@link Builder}
+         * @throws IllegalArgumentException if {@code instanceName} is {@code null}
+         * @since 1.1
+         */
+        public Builder instanceName(String instanceName) {
+            this.instanceName = Assert.requireNonNull(instanceName, "instanceName must not be null");
+            return this;
+        }
 
         /**
          * Configure the lock wait timeout via {@code SET LOCK_TIMEOUT}. {@link Duration#isNegative() Negative values} are translated to {@code -1} meaning infinite wait.
@@ -584,6 +618,7 @@ public final class MssqlConnectionConfiguration {
          */
         public Builder port(int port) {
             this.port = port;
+            this.portConfigured = true;
             return this;
         }
 
@@ -739,8 +774,8 @@ public final class MssqlConnectionConfiguration {
 
             return new MssqlConnectionConfiguration(this.applicationName, this.connectionId,
                 this.connectionProvider, this.connectTimeout, this.database, this.host, this.hostNameInCertificate,
-                this.lockWaitTimeout, this.password, this.preferCursoredExecution, this.port,
-                this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
+                this.instanceName, this.lockWaitTimeout, this.password, this.preferCursoredExecution, this.port,
+                this.portConfigured, this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
                 this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay,
                 this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword, this.username);
         }

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionFactory.java
@@ -19,6 +19,7 @@ package io.r2dbc.mssql;
 import io.r2dbc.mssql.client.Client;
 import io.r2dbc.mssql.client.ClientConfiguration;
 import io.r2dbc.mssql.client.ReactorNettyClient;
+import io.r2dbc.mssql.client.SqlServerBrowserClient;
 import io.r2dbc.mssql.codec.DefaultCodecs;
 import io.r2dbc.mssql.message.tds.Redirect;
 import io.r2dbc.mssql.util.Assert;
@@ -28,6 +29,7 @@ import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.Row;
 import reactor.core.publisher.Mono;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -43,6 +45,7 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
         "CAST(@@VERSION AS VARCHAR(255)) as VersionString";
 
     private final Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory;
+    private final BiFunction<String, String, Mono<Integer>> instancePortResolver;
 
     private final MssqlConnectionConfiguration configuration;
 
@@ -55,16 +58,28 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
      * @throws IllegalArgumentException when {@link MssqlConnectionConfiguration} is {@code null}.
      */
     public MssqlConnectionFactory(MssqlConnectionConfiguration configuration) {
-        this(MssqlConnectionFactory::connect, configuration);
+        this(MssqlConnectionFactory::connect, MssqlConnectionFactory::resolveInstancePort, configuration);
     }
 
     MssqlConnectionFactory(Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory,
                            MssqlConnectionConfiguration configuration) {
 
+        this(clientFactory, MssqlConnectionFactory::resolveInstancePort, configuration);
+
+    }
+
+    MssqlConnectionFactory(Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory,
+                           BiFunction<String, String, Mono<Integer>> instancePortResolver,
+                           MssqlConnectionConfiguration configuration) {
+
         this.clientFactory = Assert.requireNonNull(clientFactory, "clientFactory must not be null");
+        this.instancePortResolver = Assert.requireNonNull(instancePortResolver, "instancePortResolver must not be null");
         this.configuration = Assert.requireNonNull(configuration, "configuration must not be null");
     }
 
+    private static Mono<Integer> resolveInstancePort(String host, String instanceName) {
+        return new SqlServerBrowserClient().resolvePort(host, instanceName);
+    }
     private static Mono<Client> connect(MssqlConnectionConfiguration configuration) {
 
         return Mono.defer(() -> {
@@ -75,24 +90,38 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
         });
     }
 
+    Mono<MssqlConnectionConfiguration> resolveConfiguration(MssqlConnectionConfiguration configuration) {
+
+        Assert.requireNonNull(configuration, "configuration must not be null");
+
+        if (configuration.isPortConfigured() || !configuration.getInstanceName().isPresent()) {
+            return Mono.just(configuration);
+        }
+
+        String instanceName = configuration.getInstanceName().get();
+
+        return Mono.defer(() -> this.instancePortResolver.apply(configuration.getHost(), instanceName))
+            .map(configuration::withResolvedPort);
+    }
     private Mono<Client> initializeClient(MssqlConnectionConfiguration configuration, boolean allowReroute) {
 
-        LoginConfiguration loginConfiguration = configuration.getLoginConfiguration();
+        return resolveConfiguration(configuration).flatMap(resolvedConfiguration -> {
+            LoginConfiguration loginConfiguration = resolvedConfiguration.getLoginConfiguration();
 
-        return this.clientFactory.apply(configuration)
-            .delayUntil(client -> LoginFlow.exchange(client, loginConfiguration)
-                .onErrorResume(e -> propagateError(client.close(), e)))
-            .flatMap(client -> {
-                return client.getRedirect().map(redirect -> {
-                    if (allowReroute) {
-                        return redirectClient(client, redirect);
-                    } else {
-                        return this.<Client>propagateError(client.close(), new MssqlRoutingException("Client was redirected more than once"));
-                    }
-                }).orElse(Mono.just(client));
-            });
+            return this.clientFactory.apply(resolvedConfiguration)
+                .delayUntil(client -> LoginFlow.exchange(client, loginConfiguration)
+                    .onErrorResume(e -> propagateError(client.close(), e)))
+                .flatMap(client -> {
+                    return client.getRedirect().map(redirect -> {
+                        if (allowReroute) {
+                            return redirectClient(client, redirect);
+                        } else {
+                            return this.<Client>propagateError(client.close(), new MssqlRoutingException("Client was redirected more than once"));
+                        }
+                    }).orElse(Mono.just(client));
+                });
+        });
     }
-
     private Mono<Client> redirectClient(Client client, Redirect redirect) {
 
         MssqlConnectionConfiguration routeConfiguration = this.configuration.withRedirect(redirect);

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionFactoryProvider.java
@@ -64,6 +64,12 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
      * Expected Hostname in SSL certificate. Supports wildcards.
      */
     public static final Option<String> HOSTNAME_IN_CERTIFICATE = Option.valueOf("hostNameInCertificate");
+    /**
+     * SQL Server named instance.
+     *
+     * @since 1.1
+     */
+    public static final Option<String> INSTANCE_NAME = Option.valueOf("instanceName");
 
     /**
      * Configure whether to prefer cursored execution on a statement-by-statement basis. Value can be {@link Boolean}, a {@link Predicate}, or a {@link Class class name}. The {@link Predicate}
@@ -161,6 +167,7 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
         mapper.from(CONNECT_TIMEOUT).map(OptionMapper::toDuration).to(builder::connectTimeout);
         mapper.fromTyped(DATABASE).to(builder::database);
         mapper.fromTyped(HOSTNAME_IN_CERTIFICATE).to(builder::hostNameInCertificate);
+        mapper.fromTyped(INSTANCE_NAME).to(builder::instanceName);
         mapper.from(LOCK_WAIT_TIMEOUT).map(OptionMapper::toDuration).to(builder::lockWaitTimeout);
         mapper.from(PORT).map(OptionMapper::toInteger).to(builder::port);
         mapper.from(PREFER_CURSORED_EXECUTION).map(OptionMapper::toStringPredicate).to(builder::preferCursoredExecution);

--- a/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserClient.java
+++ b/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserClient.java
@@ -29,7 +29,7 @@ import reactor.netty.udp.UdpClient;
  *
  * @author Daniel Pachali
  */
-final class SqlServerBrowserClient {
+public final class SqlServerBrowserClient {
 
     private static final int DEFAULT_BROWSER_PORT = 1434;
 
@@ -42,7 +42,7 @@ final class SqlServerBrowserClient {
     /**
      * Create a SQL Server Browser client using UDP port {@code 1434}.
      */
-    SqlServerBrowserClient() {
+    public SqlServerBrowserClient() {
         this(DEFAULT_BROWSER_PORT, DEFAULT_TIMEOUT);
     }
 
@@ -73,7 +73,7 @@ final class SqlServerBrowserClient {
      * @param instanceName the SQL Server instance name.
      * @return a {@link Mono} emitting the resolved TCP port.
      */
-    Mono<Integer> resolvePort(String host, String instanceName) {
+    public Mono<Integer> resolvePort(String host, String instanceName) {
 
         Assert.requireNonNull(host, "host must not be null");
         Assert.requireNonNull(instanceName, "instanceName must not be null");

--- a/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserClient.java
+++ b/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserClient.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.util.Assert;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.netty.udp.UdpClient;
+
+/**
+ * Client for resolving named SQL Server instances through SQL Server Browser.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserClient {
+
+    private static final int DEFAULT_BROWSER_PORT = 1434;
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    private final int browserPort;
+
+    private final Duration timeout;
+
+    /**
+     * Create a SQL Server Browser client using UDP port {@code 1434}.
+     */
+    SqlServerBrowserClient() {
+        this(DEFAULT_BROWSER_PORT, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Create a SQL Server Browser client.
+     *
+     * @param browserPort the SQL Server Browser UDP port.
+     * @param timeout     the timeout for the browser request.
+     */
+    SqlServerBrowserClient(int browserPort, Duration timeout) {
+
+        Assert.isTrue(browserPort > 0 && browserPort <= 65535,
+                "browserPort must be between 1 and 65535");
+
+        this.timeout = Assert.requireNonNull(timeout,
+                "timeout must not be null");
+
+        Assert.isTrue(timeout.compareTo(Duration.ZERO) > 0,
+                "timeout must be greater than zero");
+
+        this.browserPort = browserPort;
+    }
+
+    /**
+     * Resolve the TCP port for a named SQL Server instance.
+     *
+     * @param host         the SQL Server host.
+     * @param instanceName the SQL Server instance name.
+     * @return a {@link Mono} emitting the resolved TCP port.
+     */
+    Mono<Integer> resolvePort(String host, String instanceName) {
+
+        Assert.requireNonNull(host, "host must not be null");
+        Assert.requireNonNull(instanceName, "instanceName must not be null");
+
+        Assert.isTrue(!host.isEmpty(), "host must not be empty");
+        Assert.isTrue(!instanceName.isEmpty(),
+                "instanceName must not be empty");
+
+        return Mono.defer(() -> {
+
+            Sinks.One<Integer> result = Sinks.one();
+
+            UdpClient client = UdpClient.create()
+                    .host(host)
+                    .port(this.browserPort)
+                    .handle((in, out) -> {
+
+                        ByteBuf request = out.alloc().buffer();
+
+                        try {
+                            SqlServerBrowserRequestEncoder.encode(
+                                    request,
+                                    instanceName,
+                                    StandardCharsets.US_ASCII);
+                        } catch (RuntimeException e) {
+                            request.release();
+                            return Mono.error(e);
+                        }
+
+                        return out.send(Mono.just(request))
+                                .then(in.receive()
+                                        .next()
+                                        .map(SqlServerBrowserResponseParser::parseTcpPort)
+                                        .doOnNext(port -> result.tryEmitValue(port))
+                                        .then())
+                                .then()
+                                .doOnError(error -> result.tryEmitError(error));
+                    });
+
+            Mono<Integer> resolution = client.connect()
+                    .flatMap(connection -> result.asMono()
+                            .doFinally(signalType -> connection.dispose()));
+
+            return resolution.timeout(
+                    this.timeout,
+                    Mono.error(new IllegalStateException(String.format(
+                            "SQL Server Browser did not respond for instance '%s' on host '%s' within %d ms",
+                            instanceName,
+                            host,
+                            this.timeout.toMillis()))));
+        });
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserRequestEncoder.java
+++ b/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserRequestEncoder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.util.Assert;
+
+import java.nio.charset.Charset;
+
+/**
+ * Encoder for SQL Server Browser requests.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserRequestEncoder {
+
+    private static final int CLNT_UCAST_INST = 0x04;
+
+    private static final int MAX_INSTANCE_NAME_LENGTH = 32;
+
+    private SqlServerBrowserRequestEncoder() {
+    }
+
+    /**
+     * Encode a SQL Server Browser {@code CLNT_UCAST_INST} request.
+     *
+     * @param buffer       the target {@link ByteBuf}.
+     * @param instanceName the SQL Server instance name.
+     * @param charset      the character set used to encode the instance name.
+     */
+    static void encode(ByteBuf buffer, String instanceName, Charset charset) {
+
+        Assert.requireNonNull(buffer, "buffer must not be null");
+        Assert.requireNonNull(instanceName, "instanceName must not be null");
+        Assert.requireNonNull(charset, "charset must not be null");
+
+        Assert.isTrue(!instanceName.isEmpty(),
+            "instanceName must not be empty");
+
+        Assert.isTrue(instanceName.indexOf('\0') == -1,
+            "instanceName must not contain a null character");
+
+        Assert.isTrue(charset.newEncoder().canEncode(instanceName),
+            String.format("instanceName cannot be encoded using charset %s", charset.name()));
+
+        byte[] instanceNameBytes = instanceName.getBytes(charset);
+
+        Assert.isTrue(instanceNameBytes.length <= MAX_INSTANCE_NAME_LENGTH,
+            String.format("instanceName must not exceed %d bytes", MAX_INSTANCE_NAME_LENGTH));
+
+        buffer.ensureWritable(instanceNameBytes.length + 2);
+
+        buffer.writeByte(CLNT_UCAST_INST);
+        buffer.writeBytes(instanceNameBytes);
+        buffer.writeByte(0);
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserResponseParser.java
+++ b/src/main/java/io/r2dbc/mssql/client/SqlServerBrowserResponseParser.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.message.tds.ProtocolException;
+import io.r2dbc.mssql.util.Assert;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Parser for SQL Server Browser responses.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserResponseParser {
+
+    private static final int SVR_RESP = 0x05;
+
+    private static final int MAX_INSTANCE_RESPONSE_LENGTH = 1024;
+
+    private SqlServerBrowserResponseParser() {
+    }
+
+    /**
+     * Parse the TCP port from a SQL Server Browser {@code SVR_RESP}.
+     *
+     * @param buffer the response buffer.
+     * @return the resolved TCP port.
+     */
+    static int parseTcpPort(ByteBuf buffer) {
+
+        Assert.requireNonNull(buffer, "buffer must not be null");
+
+        if (buffer.readableBytes() < 3) {
+            throw new ProtocolException("SQL Server Browser response is too short");
+        }
+
+        int responseType = buffer.readUnsignedByte();
+
+        if (responseType != SVR_RESP) {
+            throw new ProtocolException(String.format(
+                "Unexpected SQL Server Browser response type: 0x%02X", responseType));
+        }
+
+        int responseLength = buffer.readUnsignedShortLE();
+
+        if (responseLength > MAX_INSTANCE_RESPONSE_LENGTH) {
+            throw new ProtocolException(String.format(
+                "SQL Server Browser response exceeds maximum length of %d bytes",
+                MAX_INSTANCE_RESPONSE_LENGTH));
+        }
+
+        if (buffer.readableBytes() < responseLength) {
+            throw new ProtocolException(String.format(
+                "Incomplete SQL Server Browser response: expected %d bytes but received %d",
+                responseLength, buffer.readableBytes()));
+        }
+
+        String response = buffer.readCharSequence(
+            responseLength, StandardCharsets.US_ASCII).toString();
+
+        String[] tokens = response.split(";", -1);
+
+        for (int i = 0; i + 1 < tokens.length; i += 2) {
+
+            if (!"tcp".equalsIgnoreCase(tokens[i])) {
+                continue;
+            }
+
+            String portValue = tokens[i + 1];
+
+            try {
+
+                int port = Integer.parseInt(portValue);
+
+                if (port < 1 || port > 65535) {
+                    throw new ProtocolException(String.format(
+                        "Invalid TCP port in SQL Server Browser response: %s",
+                        portValue));
+                }
+
+                return port;
+
+            } catch (NumberFormatException e) {
+                throw new ProtocolException(String.format(
+                    "Invalid TCP port in SQL Server Browser response: %s",
+                    portValue), e);
+            }
+        }
+
+        throw new ProtocolException(
+            "SQL Server Browser response does not contain TCP protocol information");
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionConfigurationUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionConfigurationUnitTests.java
@@ -71,6 +71,11 @@ final class MssqlConnectionConfigurationUnitTests {
         assertThatIllegalArgumentException().isThrownBy(() -> MssqlConnectionConfiguration.builder().host(null))
                 .withMessage("host must not be null");
     }
+    @Test
+    void builderNoInstanceName() {
+        assertThatIllegalArgumentException().isThrownBy(() -> MssqlConnectionConfiguration.builder().instanceName(null))
+                .withMessage("instanceName must not be null");
+    }
 
     @Test
     void builderNoPassword() {
@@ -93,6 +98,7 @@ final class MssqlConnectionConfigurationUnitTests {
                 .connectionId(connectionId)
                 .database("test-database")
                 .host("test-host")
+                .instanceName("SQLEXPRESS")
                 .password("test-password")
                 .preferCursoredExecution(TRUE)
                 .port(100)
@@ -106,9 +112,11 @@ final class MssqlConnectionConfigurationUnitTests {
                 .hasFieldOrPropertyWithValue("connectionProvider", connectionProvider)
                 .hasFieldOrPropertyWithValue("database", "test-database")
                 .hasFieldOrPropertyWithValue("host", "test-host")
+                .hasFieldOrPropertyWithValue("instanceName", "SQLEXPRESS")
                 .hasFieldOrPropertyWithValue("password", "test-password")
                 .hasFieldOrPropertyWithValue("preferCursoredExecution", TRUE)
                 .hasFieldOrPropertyWithValue("port", 100)
+                .hasFieldOrPropertyWithValue("portConfigured", true)
                 .hasFieldOrPropertyWithValue("username", "test-username")
                 .hasFieldOrPropertyWithValue("sendStringParametersAsUnicode", false);
 
@@ -128,10 +136,41 @@ final class MssqlConnectionConfigurationUnitTests {
                 .hasFieldOrPropertyWithValue("applicationName", "r2dbc")
                 .hasFieldOrPropertyWithValue("database", "test-database")
                 .hasFieldOrPropertyWithValue("host", "test-host")
+                .hasFieldOrPropertyWithValue("instanceName", null)
                 .hasFieldOrPropertyWithValue("password", "test-password")
                 .hasFieldOrPropertyWithValue("port", 1433)
+                .hasFieldOrPropertyWithValue("portConfigured", false)
                 .hasFieldOrPropertyWithValue("username", "test-username")
                 .hasFieldOrPropertyWithValue("sendStringParametersAsUnicode", true);
+    }
+
+    @Test
+    void namedInstanceDoesNotConfigureDefaultPortExplicitly() {
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+                .host("test-host")
+                .instanceName("SQLEXPRESS")
+                .password("test-password")
+                .username("test-username")
+                .build();
+
+        assertThat(configuration.getInstanceName()).contains("SQLEXPRESS");
+        assertThat(configuration.getPort()).isEqualTo(MssqlConnectionConfiguration.DEFAULT_PORT);
+        assertThat(configuration.isPortConfigured()).isFalse();
+    }
+
+    @Test
+    void explicitPortIsTrackedForNamedInstance() {
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+                .host("test-host")
+                .instanceName("SQLEXPRESS")
+                .port(1433)
+                .password("test-password")
+                .username("test-username")
+                .build();
+
+        assertThat(configuration.getInstanceName()).contains("SQLEXPRESS");
+        assertThat(configuration.getPort()).isEqualTo(1433);
+        assertThat(configuration.isPortConfigured()).isTrue();
     }
 
     @Test
@@ -175,6 +214,7 @@ final class MssqlConnectionConfigurationUnitTests {
                 .applicationName("r2dbc")
                 .database("test-database")
                 .host("test-host")
+                .instanceName("SQLEXPRESS")
                 .password("test-password")
                 .username("test-username")
                 .build();
@@ -185,8 +225,10 @@ final class MssqlConnectionConfigurationUnitTests {
                 .hasFieldOrPropertyWithValue("applicationName", "r2dbc")
                 .hasFieldOrPropertyWithValue("database", "test-database")
                 .hasFieldOrPropertyWithValue("host", "target")
+                .hasFieldOrPropertyWithValue("instanceName", null)
                 .hasFieldOrPropertyWithValue("password", "test-password")
                 .hasFieldOrPropertyWithValue("port", 1234)
+                .hasFieldOrPropertyWithValue("portConfigured", true)
                 .hasFieldOrPropertyWithValue("username", "test-username")
                 .hasFieldOrPropertyWithValue("sendStringParametersAsUnicode", true)
                 .hasFieldOrPropertyWithValue("hostNameInCertificate", "test-host");

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryProviderTest.java
@@ -144,6 +144,40 @@ final class MssqlConnectionFactoryProviderTest {
     }
 
     @Test
+    void shouldConfigureNamedInstance() {
+        MssqlConnectionFactory factory = this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, MSSQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(INSTANCE_NAME, "SQLEXPRESS")
+            .build());
+
+        MssqlConnectionConfiguration configuration = factory.getConfiguration();
+
+        assertThat(configuration.getInstanceName()).contains("SQLEXPRESS");
+        assertThat(configuration.isPortConfigured()).isFalse();
+    }
+
+    @Test
+    void shouldConfigureNamedInstanceWithExplicitPort() {
+        MssqlConnectionFactory factory = this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, MSSQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(PASSWORD, "test-password")
+            .option(USER, "test-user")
+            .option(INSTANCE_NAME, "SQLEXPRESS")
+            .option(PORT, 51432)
+            .build());
+
+        MssqlConnectionConfiguration configuration = factory.getConfiguration();
+
+        assertThat(configuration.getInstanceName()).contains("SQLEXPRESS");
+        assertThat(configuration.getPort()).isEqualTo(51432);
+        assertThat(configuration.isPortConfigured()).isTrue();
+    }
+
+    @Test
     void shouldConfigureWithStringAsUnicode() {
 
         MssqlConnectionFactory factory = this.provider.create(ConnectionFactoryOptions.builder()

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryUnitTests.java
@@ -32,6 +32,8 @@ import reactor.util.annotation.Nullable;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -65,6 +67,140 @@ class MssqlConnectionFactoryUnitTests {
             .withMessage("configuration must not be null");
     }
 
+    @Test
+    void constructorNoInstancePortResolver() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new MssqlConnectionFactory(config -> Mono.empty(), null, this.configuration))
+            .withMessage("instancePortResolver must not be null");
+    }
+
+    @Test
+    void shouldResolveNamedInstanceWhenPortIsNotExplicitlyConfigured() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+            .host("sql01")
+            .instanceName("SQLEXPRESS")
+            .username("user")
+            .password("password")
+            .build();
+
+        AtomicReference<String> resolvedHost = new AtomicReference<>();
+        AtomicReference<String> resolvedInstance = new AtomicReference<>();
+
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> Mono.empty(), (host, instanceName) -> {
+            resolvedHost.set(host);
+            resolvedInstance.set(instanceName);
+            return Mono.just(51432);
+        }, configuration);
+
+        StepVerifier.create(connectionFactory.resolveConfiguration(configuration))
+            .assertNext(resolved -> {
+                assertThat(resolved.getHost()).isEqualTo("sql01");
+                assertThat(resolved.getInstanceName()).contains("SQLEXPRESS");
+                assertThat(resolved.getPort()).isEqualTo(51432);
+                assertThat(resolved.isPortConfigured()).isTrue();
+            })
+            .verifyComplete();
+
+        assertThat(resolvedHost.get()).isEqualTo("sql01");
+        assertThat(resolvedInstance.get()).isEqualTo("SQLEXPRESS");
+    }
+
+    @Test
+    void shouldSkipNamedInstanceResolutionWithoutInstanceName() {
+
+        AtomicBoolean resolverCalled = new AtomicBoolean();
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> Mono.empty(), (host, instanceName) -> {
+            resolverCalled.set(true);
+            return Mono.just(51432);
+        }, this.configuration);
+
+        StepVerifier.create(connectionFactory.resolveConfiguration(this.configuration))
+            .expectNext(this.configuration)
+            .verifyComplete();
+
+        assertThat(resolverCalled.get()).isFalse();
+    }
+
+    @Test
+    void shouldSkipNamedInstanceResolutionWhenPortIsExplicitlyConfigured() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+            .host("sql01")
+            .instanceName("SQLEXPRESS")
+            .port(1433)
+            .username("user")
+            .password("password")
+            .build();
+
+        AtomicBoolean resolverCalled = new AtomicBoolean();
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> Mono.empty(), (host, instanceName) -> {
+            resolverCalled.set(true);
+            return Mono.just(51432);
+        }, configuration);
+
+        StepVerifier.create(connectionFactory.resolveConfiguration(configuration))
+            .expectNext(configuration)
+            .verifyComplete();
+
+        assertThat(resolverCalled.get()).isFalse();
+        assertThat(configuration.getPort()).isEqualTo(1433);
+        assertThat(configuration.isPortConfigured()).isTrue();
+    }
+
+    @Test
+    void shouldPropagateNamedInstanceResolutionFailure() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+            .host("sql01")
+            .instanceName("SQLEXPRESS")
+            .username("user")
+            .password("password")
+            .build();
+
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> Mono.empty(),
+            (host, instanceName) -> Mono.error(new IllegalStateException("browser failure")), configuration);
+
+        StepVerifier.create(connectionFactory.resolveConfiguration(configuration))
+            .expectErrorMatches(error -> error instanceof IllegalStateException && error.getMessage().equals("browser failure"))
+            .verify();
+    }
+
+    @Test
+    void shouldConnectUsingResolvedNamedInstancePort() {
+
+        ColumnMetadataToken columns = ColumnMetadataToken.create(COLUMNS);
+        RowToken rowToken = RowTokenFactory.create(columns, buffer -> {
+            Encode.uString(buffer, "Edition", ServerCharset.UNICODE.charset());
+            Encode.uString(buffer, "1.2.3", ServerCharset.CP1252.charset());
+        });
+
+        TestClient client = TestClient.builder().assertNextRequestWith(clientMessage -> {
+            assertThat(clientMessage).isInstanceOf(Prelogin.class);
+        }).thenRespond(DoneToken.create(0)).assertNextRequestWith(clientMessage -> {
+            assertThat(clientMessage).isInstanceOf(SqlBatch.class);
+        }).thenRespond(columns, rowToken, DoneToken.create(1)).build();
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+            .host("sql01")
+            .instanceName("SQLEXPRESS")
+            .username("user")
+            .password("password")
+            .build();
+
+        AtomicReference<MssqlConnectionConfiguration> connectedConfiguration = new AtomicReference<>();
+
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> {
+            connectedConfiguration.set(config);
+            return Mono.just(client);
+        }, (host, instanceName) -> Mono.just(51432), configuration);
+
+        connectionFactory.create().as(StepVerifier::create).expectNextCount(1).verifyComplete();
+
+        assertThat(connectedConfiguration.get()).isNotNull();
+        assertThat(connectedConfiguration.get().getHost()).isEqualTo("sql01");
+        assertThat(connectedConfiguration.get().getPort()).isEqualTo(51432);
+        assertThat(connectedConfiguration.get().isPortConfigured()).isTrue();
+    }
     @Test
     void shouldFollowRedirect() {
 

--- a/src/test/java/io/r2dbc/mssql/NamedInstanceIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/NamedInstanceIntegrationTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.socket.DatagramPacket;
+import io.r2dbc.mssql.util.IntegrationTestSupport;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.netty.Connection;
+import reactor.netty.udp.UdpServer;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for SQL Server named-instance discovery.
+ *
+ * <p>The SQL Server itself is provided by the existing Testcontainers-based
+ * {@link IntegrationTestSupport}. SQL Server on Linux does not provide named
+ * instances or SQL Server Browser, so this test supplies only the SSRP endpoint
+ * with an in-process UDP server. The SSRP response points to the mapped TCP port
+ * of the real SQL Server Testcontainer.
+ *
+ * @author Daniel Pachali
+ */
+class NamedInstanceIntegrationTests extends IntegrationTestSupport {
+
+    private static final int SQL_BROWSER_PORT = 1434;
+
+    private static final String INSTANCE_NAME = "SQLEXPRESS";
+
+    private static final Duration SERVER_START_TIMEOUT = Duration.ofSeconds(5);
+
+    private Connection browserServer;
+
+    @AfterEach
+    void stopBrowserServer() {
+
+        if (this.browserServer != null) {
+            this.browserServer.disposeNow(Duration.ofSeconds(5));
+        }
+    }
+
+    @Test
+    void shouldResolveNamedInstanceAndConnectToSqlServer() {
+
+        AtomicReference<byte[]> receivedRequest = new AtomicReference<>();
+
+        startBrowserServer(receivedRequest);
+
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+            .option(DRIVER, MssqlConnectionFactoryProvider.MSSQL_DRIVER)
+            .option(HOST, SERVER.getHost())
+            .option(DATABASE, "master")
+            .option(USER, SERVER.getUsername())
+            .option(PASSWORD, SERVER.getPassword())
+            .option(MssqlConnectionFactoryProvider.INSTANCE_NAME, INSTANCE_NAME)
+            .build();
+
+        MssqlConnectionFactory connectionFactory =
+            (MssqlConnectionFactory) ConnectionFactories.get(options);
+
+        Flux.usingWhen(
+                connectionFactory.create(),
+                connection -> connection.createStatement("SELECT 1 AS value")
+                    .execute()
+                    .flatMap(result -> result.map((row, metadata) ->
+                        row.get("value", Integer.class))),
+                MssqlConnection::close)
+            .as(StepVerifier::create)
+            .expectNext(1)
+            .verifyComplete();
+
+        assertThat(receivedRequest.get()).isNotNull();
+        assertThat(ByteBufUtil.hexDump(receivedRequest.get()))
+            .isEqualToIgnoringCase("0453514c4558505245535300");
+    }
+
+    private void startBrowserServer(AtomicReference<byte[]> receivedRequest) {
+
+        this.browserServer = UdpServer.create()
+            .host(SERVER.getHost())
+            .port(SQL_BROWSER_PORT)
+            .handle((in, out) -> out.sendObject(
+                in.receiveObject()
+                    .ofType(DatagramPacket.class)
+                    .map(packet -> {
+                        receivedRequest.set(ByteBufUtil.getBytes(packet.content()));
+
+                        return new DatagramPacket(
+                            browserResponse(
+                                "ServerName;TESTCONTAINER;" +
+                                    "InstanceName;" + INSTANCE_NAME + ";" +
+                                    "IsClustered;No;" +
+                                    "Version;16.0.1000.6;" +
+                                    "tcp;" + SERVER.getPort() + ";;"),
+                            packet.sender());
+                    })))
+            .bindNow(SERVER_START_TIMEOUT);
+    }
+
+    private static ByteBuf browserResponse(String responseData) {
+
+        byte[] bytes = responseData.getBytes(StandardCharsets.US_ASCII);
+
+        ByteBuf buffer = Unpooled.buffer(3 + bytes.length);
+
+        buffer.writeByte(0x05);
+        buffer.writeShortLE(bytes.length);
+        buffer.writeBytes(bytes);
+
+        return buffer;
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserClientUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserClientUnitTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.socket.DatagramPacket;
+import io.r2dbc.mssql.message.tds.ProtocolException;
+import reactor.netty.Connection;
+import reactor.netty.udp.UdpServer;
+import reactor.test.StepVerifier;
+
+/**
+ * Unit tests for {@link SqlServerBrowserClient}.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserClientUnitTests {
+
+    private static final String LOOPBACK_ADDRESS = "127.0.0.1";
+
+    private static final Duration SERVER_START_TIMEOUT = Duration.ofSeconds(5);
+
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(2);
+
+    private Connection server;
+
+    @AfterEach
+    void tearDown() {
+
+        if (this.server != null) {
+            this.server.disposeNow(Duration.ofSeconds(5));
+        }
+    }
+
+    @Test
+    void shouldResolveTcpPortAndSendNamedInstanceRequest() {
+
+        AtomicReference<byte[]> receivedRequest = new AtomicReference<>();
+
+        startRespondingServer(packet -> {
+
+            receivedRequest.set(
+                    ByteBufUtil.getBytes(packet.content()));
+
+            return browserResponse(
+                    "ServerName;SQL01;" +
+                            "InstanceName;SQLEXPRESS;" +
+                            "IsClustered;No;" +
+                            "Version;16.0.1000.6;" +
+                            "tcp;49731;;");
+        });
+
+        SqlServerBrowserClient client = new SqlServerBrowserClient(serverPort(), TEST_TIMEOUT);
+
+        StepVerifier.create(
+                client.resolvePort(LOOPBACK_ADDRESS, "SQLEXPRESS"))
+                .expectNext(49731)
+                .expectComplete()
+                .verify(Duration.ofSeconds(5));
+
+        assertThat(receivedRequest.get()).isNotNull();
+
+        assertThat(ByteBufUtil.hexDump(receivedRequest.get()))
+                .isEqualToIgnoringCase(
+                        "0453514c4558505245535300");
+    }
+
+    @Test
+    void shouldPropagateInvalidBrowserResponse() {
+
+        startRespondingServer(packet -> browserResponse(
+                "ServerName;SQL01;" +
+                        "InstanceName;SQLEXPRESS;" +
+                        "IsClustered;No;" +
+                        "Version;16.0.1000.6;;"));
+
+        SqlServerBrowserClient client = new SqlServerBrowserClient(serverPort(), TEST_TIMEOUT);
+
+        StepVerifier.create(
+                client.resolvePort(LOOPBACK_ADDRESS, "SQLEXPRESS"))
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(ProtocolException.class)
+                        .hasMessageContaining(
+                                "does not contain TCP protocol information"))
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldTimeoutWhenBrowserDoesNotRespond() {
+
+        startSilentServer();
+
+        SqlServerBrowserClient client = new SqlServerBrowserClient(
+                serverPort(),
+                Duration.ofMillis(500));
+
+        StepVerifier.create(
+                client.resolvePort(LOOPBACK_ADDRESS, "SQLEXPRESS"))
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining(
+                                "SQL Server Browser did not respond")
+                        .hasMessageContaining("SQLEXPRESS"))
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldRejectInvalidArguments() {
+
+        SqlServerBrowserClient client = new SqlServerBrowserClient(
+                1434,
+                Duration.ofSeconds(1));
+
+        assertThatThrownBy(() -> client.resolvePort(null, "SQLEXPRESS"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host must not be null");
+
+        assertThatThrownBy(() -> client.resolvePort("", "SQLEXPRESS"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host must not be empty");
+
+        assertThatThrownBy(() -> client.resolvePort("SQL01", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "instanceName must not be null");
+
+        assertThatThrownBy(() -> client.resolvePort("SQL01", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "instanceName must not be empty");
+    }
+
+    @Test
+    void shouldRejectInvalidConfiguration() {
+
+        assertThatThrownBy(() -> new SqlServerBrowserClient(
+                0,
+                Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "browserPort must be between 1 and 65535");
+
+        assertThatThrownBy(() -> new SqlServerBrowserClient(
+                65536,
+                Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "browserPort must be between 1 and 65535");
+
+        assertThatThrownBy(() -> new SqlServerBrowserClient(1434, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("timeout must not be null");
+
+        assertThatThrownBy(() -> new SqlServerBrowserClient(
+                1434,
+                Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "timeout must be greater than zero");
+    }
+
+    private void startRespondingServer(
+            Function<DatagramPacket, ByteBuf> responseFactory) {
+
+        this.server = UdpServer.create()
+                .host(LOOPBACK_ADDRESS)
+                .port(0)
+                .handle((in, out) -> out.sendObject(
+                        in.receiveObject()
+                                .ofType(DatagramPacket.class)
+                                .map(packet -> new DatagramPacket(
+                                        responseFactory.apply(packet),
+                                        packet.sender()))))
+                .bindNow(SERVER_START_TIMEOUT);
+    }
+
+    private void startSilentServer() {
+
+        this.server = UdpServer.create()
+                .host(LOOPBACK_ADDRESS)
+                .port(0)
+                .handle((in, out) -> in.receive().then())
+                .bindNow(SERVER_START_TIMEOUT);
+    }
+
+    private int serverPort() {
+
+        return ((InetSocketAddress) this.server.address())
+                .getPort();
+    }
+
+    private static ByteBuf browserResponse(
+            String responseData) {
+
+        byte[] bytes = responseData.getBytes(StandardCharsets.US_ASCII);
+
+        ByteBuf buffer = Unpooled.buffer(3 + bytes.length);
+
+        buffer.writeByte(0x05);
+        buffer.writeShortLE(bytes.length);
+        buffer.writeBytes(bytes);
+
+        return buffer;
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserRequestEncoderUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserRequestEncoderUnitTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SqlServerBrowserRequestEncoder}.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserRequestEncoderUnitTests {
+
+    @Test
+    void shouldEncodeNamedInstanceRequest() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        SqlServerBrowserRequestEncoder.encode(
+            buffer, "SQLEXPRESS", StandardCharsets.US_ASCII);
+
+        assertThat(buffer.writerIndex()).isEqualTo(12);
+
+        assertThat(ByteBufUtil.hexDump(buffer))
+            .isEqualToIgnoringCase("0453514c4558505245535300");
+    }
+
+    @Test
+    void shouldEncodeInstanceNameContainingAllowedCharacters() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        SqlServerBrowserRequestEncoder.encode(
+            buffer, "SQL_2026$", StandardCharsets.US_ASCII);
+
+        assertThat((int) buffer.readUnsignedByte()).isEqualTo(0x04);
+
+        assertThat(buffer.readCharSequence(
+            buffer.readableBytes() - 1, StandardCharsets.US_ASCII))
+            .hasToString("SQL_2026$");
+
+        assertThat(buffer.readUnsignedByte()).isZero();
+    }
+
+    @Test
+    void shouldEncodeMaximumLengthInstanceName() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        String instanceName = repeat('A', 32);
+
+        SqlServerBrowserRequestEncoder.encode(
+            buffer, instanceName, StandardCharsets.US_ASCII);
+
+        assertThat(buffer.writerIndex()).isEqualTo(34);
+        assertThat((int) buffer.getUnsignedByte(0)).isEqualTo(0x04);
+        assertThat(buffer.getUnsignedByte(33)).isZero();
+    }
+
+    @Test
+    void shouldRejectInstanceNameExceedingMaximumLength() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        String instanceName = repeat('A', 33);
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, instanceName, StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not exceed 32 bytes");
+    }
+
+    @Test
+    void shouldRejectEmptyInstanceName() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, "", StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void shouldRejectInstanceNameContainingNullCharacter() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, "SQL\0EXPRESS", StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must not contain a null character");
+    }
+
+    @Test
+    void shouldRejectInstanceNameNotRepresentableByCharset() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, "MÜNCHEN", StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("cannot be encoded using charset");
+    }
+
+    @Test
+    void shouldRejectNullArguments() {
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                null, "SQLEXPRESS", StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("buffer must not be null");
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, null, StandardCharsets.US_ASCII))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("instanceName must not be null");
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserRequestEncoder.encode(
+                buffer, "SQLEXPRESS", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("charset must not be null");
+    }
+
+    private static String repeat(char character, int count) {
+
+        char[] characters = new char[count];
+
+        Arrays.fill(characters, character);
+
+        return new String(characters);
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserResponseParserUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/client/SqlServerBrowserResponseParserUnitTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.r2dbc.mssql.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.r2dbc.mssql.message.tds.ProtocolException;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SqlServerBrowserResponseParser}.
+ *
+ * @author Daniel Pachali
+ */
+final class SqlServerBrowserResponseParserUnitTests {
+
+    @Test
+    void shouldParseTcpPort() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "tcp;49731;;");
+
+        assertThat(SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isEqualTo(49731);
+    }
+
+    @Test
+    void shouldParseTcpPortRegardlessOfProtocolOrderAndCase() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "np;\\\\SQL01\\pipe\\MSSQL$SQLEXPRESS\\sql\\query;" +
+                "TCP;51432;;");
+
+        assertThat(SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isEqualTo(51432);
+    }
+
+    @Test
+    void shouldRejectUnexpectedResponseType() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "tcp;49731;;");
+
+        response.setByte(0, 0x04);
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isInstanceOf(ProtocolException.class)
+            .hasMessageContaining(
+                "Unexpected SQL Server Browser response type");
+    }
+
+    @Test
+    void shouldRejectIncompleteResponse() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "tcp;49731;;");
+
+        response.writerIndex(response.writerIndex() - 2);
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isInstanceOf(ProtocolException.class)
+            .hasMessageContaining(
+                "Incomplete SQL Server Browser response");
+    }
+
+    @Test
+    void shouldRejectMissingTcpProtocol() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "np;\\\\SQL01\\pipe\\MSSQL$SQLEXPRESS\\sql\\query;;");
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isInstanceOf(ProtocolException.class)
+            .hasMessageContaining(
+                "does not contain TCP protocol information");
+    }
+
+    @Test
+    void shouldRejectInvalidTcpPort() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "tcp;invalid;;");
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isInstanceOf(ProtocolException.class)
+            .hasMessageContaining(
+                "Invalid TCP port in SQL Server Browser response");
+    }
+
+    @Test
+    void shouldRejectTcpPortOutsideValidRange() {
+
+        ByteBuf response = response(
+            "ServerName;SQL01;" +
+                "InstanceName;SQLEXPRESS;" +
+                "IsClustered;No;" +
+                "Version;16.0.1000.6;" +
+                "tcp;65536;;");
+
+        assertThatThrownBy(() ->
+            SqlServerBrowserResponseParser.parseTcpPort(response))
+            .isInstanceOf(ProtocolException.class)
+            .hasMessageContaining(
+                "Invalid TCP port in SQL Server Browser response");
+    }
+
+    private static ByteBuf response(String responseData) {
+
+        byte[] bytes = responseData.getBytes(StandardCharsets.US_ASCII);
+
+        ByteBuf buffer = Unpooled.buffer(3 + bytes.length);
+
+        buffer.writeByte(0x05);
+        buffer.writeShortLE(bytes.length);
+        buffer.writeBytes(bytes);
+
+        return buffer;
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds support for connecting to SQL Server named instances by resolving the
instance TCP port through SQL Server Browser using the SQL Server Resolution
Protocol (SSRP).

Closes #129.

## Usage

Named instances can be configured using the `instanceName` connection option:

```text
r2dbc:mssql://host/database?instanceName=SQLEXPRESS
```

or programmatically:

```java
MssqlConnectionConfiguration configuration =
    MssqlConnectionConfiguration.builder()
        .host("host")
        .instanceName("SQLEXPRESS")
        .database("database")
        .username("user")
        .password("password")
        .build();
```

The option is also exposed through:

```java
MssqlConnectionFactoryProvider.INSTANCE_NAME
```

## Connection behavior

The connection target is selected using the following precedence:

- `host` -> connect using the default TCP port `1433`
- `host` + explicit `port` -> use the configured port
- `host` + `instanceName` -> resolve the TCP port through SQL Server Browser
- `host` + `instanceName` + explicit `port` -> the explicit port takes precedence
  and SQL Server Browser discovery is skipped

SQL Server routing redirects use the host and port supplied by the server and do
not trigger another named-instance lookup.

## Implementation

This change adds:

- SSRP `CLNT_UCAST_INST` request encoding
- SQL Server Browser response parsing
- Reactive UDP-based SQL Server Browser client
- `instanceName` support in `MssqlConnectionConfiguration`
- `instanceName` support in `MssqlConnectionFactoryProvider`
- Named-instance resolution before establishing the TDS connection
- Explicit-port precedence tracking
- Named-instance handling for TDS redirects
- README documentation

SQL Server Browser discovery uses UDP port `1434`.

## Testing

The implementation includes unit tests for:

- SSRP request encoding
- SSRP response parsing
- UDP SQL Server Browser communication
- Named-instance configuration
- Explicit-port precedence
- Resolver error propagation
- Connection setup using a resolved instance port
- Redirect behavior

A Testcontainers-based integration test verifies the complete connection path:

1. A SQL Server Testcontainer starts with a dynamically mapped TCP port.
2. An SSRP test endpoint responds to the real UDP discovery request.
3. The driver resolves the dynamic TCP port.
4. `MssqlConnectionFactory` connects to the real SQL Server container.
5. A real TDS connection executes `SELECT 1`.

Validation performed locally:

- 923 unit/regression tests passed
- 167 integration tests passed
- `mvn clean verify` completed successfully

## Requirements

For named-instance discovery:

- SQL Server Browser must be running on the target server.
- UDP port `1434` must be reachable from the client.

An explicitly configured TCP port does not require SQL Server Browser.
