### PR TITLE
Add Windows Integrated Security support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This driver provides the following features:
 
 * Complies with R2DBC 1.0
 * Login with username/password with temporary SSL encryption
+* Windows Integrated Security using the credentials of the current Windows process
 * Full SSL encryption support (for e.g. Azure usage).
 * Transaction Control
 * Simple execution of SQL batches (direct and cursored execution)
@@ -70,6 +71,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `driver`                        | Must be `sqlserver`.                                                                                                                                                                                                                                                      
 | `host`                          | Server hostname to connect to.                                                                                                                                                                                                                                            
 | `port`                          | Server port to connect to. Defaults to `1433`. _(Optional)_                                                                                                                                                                                                               
+| `integratedSecurity`            | Use Windows Integrated Security with the credentials of the current Windows process. When enabled, `username` and `password` are not required. Windows only. Defaults to `false`. _(Optional)_
 | `username`                      | Login username.                                                                                                                                                                                                                                                           
 | `password`                      | Login password.                                                                                                                                                                                                                                                           
 | `database`                      | Initial database to select. Defaults to SQL Server user profile settings. _(Optional)_                                                                                                                                                                                    
@@ -106,6 +108,85 @@ MssqlConnectionFactory factory = new MssqlConnectionFactory(configuration);
 
 Mono<MssqlConnection> connectionMono = factory.create();
 ```
+
+### Windows Integrated Security
+
+Windows Integrated Security uses the credentials of the current Windows process through
+Windows SSPI with the `Negotiate` security package. SQL Server authentication with
+username/password remains unchanged.
+
+URL-based configuration:
+
+```java
+ConnectionFactory connectionFactory = ConnectionFactories.get(
+    "r2dbc:mssql://sql.example.com:1433/database?integratedSecurity=true");
+```
+
+Programmatic discovery:
+
+```java
+ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+    .option(DRIVER, "sqlserver")
+    .option(HOST, "sql.example.com")
+    .option(PORT, 1433)
+    .option(DATABASE, "database")
+    .option(Option.valueOf("integratedSecurity"), true)
+    .build();
+
+ConnectionFactory connectionFactory = ConnectionFactories.get(options);
+```
+
+Direct configuration:
+
+```java
+MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+    .host("sql.example.com")
+    .port(1433)
+    .database("database")
+    .integratedSecurity()
+    .build();
+
+MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(configuration);
+```
+
+Integrated Security is currently supported on Windows only. It uses the identity of the
+process running the JVM; explicit Windows username/password credentials are not part of
+this authentication mode. The SQL Server instance must permit Windows authentication and
+the current process identity must have a SQL Server login or otherwise be granted access.
+
+The driver constructs the SQL Server service principal name (SPN) from the connection
+endpoint as `MSSQLSvc/<host>:<port>`. Use the SQL Server DNS/FQDN as the host when Kerberos
+authentication is required. Windows `Negotiate` determines whether Kerberos or NTLM is
+used according to the Windows environment and security policy.
+
+Windows Integrated Security uses JNA to access Windows SSPI. JNA is an optional driver
+dependency, so applications using Integrated Security must include `jna-platform`:
+
+```xml
+<dependency>
+  <groupId>net.java.dev.jna</groupId>
+  <artifactId>jna-platform</artifactId>
+  <version>5.17.0</version>
+</dependency>
+```
+
+The Windows Integrated Security integration test is intentionally not backed by the
+regular SQL Server Testcontainers setup because it requires a real Windows identity and
+an SQL Server configured to accept that identity. On Windows, configure at least
+`R2DBC_MSSQL_INTEGRATED_HOST`; the other variables are optional:
+
+```powershell
+$env:R2DBC_MSSQL_INTEGRATED_HOST = "sql.example.com"
+$env:R2DBC_MSSQL_INTEGRATED_PORT = "1433"
+$env:R2DBC_MSSQL_INTEGRATED_DATABASE = "master"
+$env:R2DBC_MSSQL_INTEGRATED_EXPECTED_USER = "DOMAIN\user"
+$env:R2DBC_MSSQL_INTEGRATED_SSL = "false"
+$env:R2DBC_MSSQL_INTEGRATED_TRUST_SERVER_CERTIFICATE = "false"
+
+.\mvnw.cmd "-Dtest=WindowsIntegratedSecurityIntegrationTests" test
+```
+
+If `R2DBC_MSSQL_INTEGRATED_HOST` is not set, the integration test is skipped.
 
 Microsoft SQL Server uses named parameters that are prefixed with `@`. The following SQL statement makes use of parameters:
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <assertj.version>3.27.7</assertj.version>
         <hikari-cp.version>7.1.0</hikari-cp.version>
         <java.version>1.8</java.version>
+        <jna.version>5.17.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <junit.version>5.14.4</junit.version>
         <jmh.version>1.37</jmh.version>
@@ -127,6 +128,12 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>${mssql-jdbc.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>${jna.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/io/r2dbc/mssql/IntegratedAuthentication.java
+++ b/src/main/java/io/r2dbc/mssql/IntegratedAuthentication.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Produces SSPI/SPNEGO tokens for integrated authentication.
+ *
+ * Implementations are responsible for maintaining authentication context between calls.
+ *
+ * @author Daniel Pachali
+ */
+interface IntegratedAuthentication {
+
+    /**
+     * Produce the initial SSPI/SPNEGO token embedded in LOGIN7.
+     *
+     * @return a {@link Mono} emitting exactly one authentication token.
+     */
+    Mono<byte[]> initialToken();
+
+    /**
+     * Process a server SSPI challenge and produce the next client response token.
+     *
+     * @param serverToken the server SSPI challenge.
+     * @return a {@link Mono} emitting exactly one authentication response token.
+     */
+    Mono<byte[]> nextToken(byte[] serverToken);
+
+    /**
+     * Release authentication resources.
+     *
+     * @return completion signal.
+     */
+    Mono<Void> close();
+
+}

--- a/src/main/java/io/r2dbc/mssql/IntegratedAuthentication.java
+++ b/src/main/java/io/r2dbc/mssql/IntegratedAuthentication.java
@@ -38,7 +38,9 @@ interface IntegratedAuthentication {
      * Process a server SSPI challenge and produce the next client response token.
      *
      * @param serverToken the server SSPI challenge.
-     * @return a {@link Mono} emitting exactly one authentication response token.
+     * @return a {@link Mono} emitting an authentication response token, or completing empty when
+     * the authentication context is complete and no final client token needs to be sent to the
+     * server.
      */
     Mono<byte[]> nextToken(byte[] serverToken);
 

--- a/src/main/java/io/r2dbc/mssql/LoginFlow.java
+++ b/src/main/java/io/r2dbc/mssql/LoginFlow.java
@@ -26,9 +26,13 @@ import io.r2dbc.mssql.message.token.DoneToken;
 import io.r2dbc.mssql.message.token.ErrorToken;
 import io.r2dbc.mssql.message.token.Login7;
 import io.r2dbc.mssql.message.token.Prelogin;
+import io.r2dbc.mssql.message.token.SspiMessage;
+import io.r2dbc.mssql.message.token.SspiToken;
 import io.r2dbc.mssql.util.Assert;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
+import reactor.util.annotation.Nullable;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +58,30 @@ final class LoginFlow {
         Assert.requireNonNull(client, "client must not be null");
         Assert.requireNonNull(login, "Login must not be null");
 
+        return exchange0(client, login, null);
+    }
+
+    /**
+     * Exchange login messages using integrated authentication.
+     *
+     * @param client         the {@link Client} to exchange messages with
+     * @param login          the login configuration for login negotiation
+     * @param authentication the integrated authentication provider
+     * @return the messages received after authentication is complete, in response to this exchange
+     */
+    static Flux<Message> exchange(Client client, LoginConfiguration login, IntegratedAuthentication authentication) {
+
+        Assert.requireNonNull(client, "client must not be null");
+        Assert.requireNonNull(login, "Login must not be null");
+        Assert.requireNonNull(authentication, "Integrated authentication must not be null");
+
+        return Flux.usingWhen(Mono.just(authentication),
+            it -> exchange0(client, login, it),
+            IntegratedAuthentication::close);
+    }
+
+    private static Flux<Message> exchange0(Client client, LoginConfiguration login,
+                                           @Nullable IntegratedAuthentication authentication) {
 
         Prelogin.Builder builder = Prelogin.builder();
         if (login.getConnectionId() != null) {
@@ -65,13 +93,16 @@ final class LoginFlow {
         }
 
         AtomicReference<Prelogin> preloginResponse = new AtomicReference<>();
-        Sinks.Many<ClientMessage> requests = Sinks.many().unicast().onBackpressureBuffer();
+        Sinks.Many<Mono<? extends ClientMessage>> requests = Sinks.many().unicast().onBackpressureBuffer();
 
         Prelogin request = builder.build();
-        requests.emitNext(request, Sinks.EmitFailureHandler.FAIL_FAST);
+        requests.emitNext(Mono.just(request), Sinks.EmitFailureHandler.FAIL_FAST);
 
-        return client.exchange(requests.asFlux(), DoneToken::isDone) //
-            .filter(or(Prelogin.class::isInstance, SslState.class::isInstance, DoneToken.class::isInstance, ErrorToken.class::isInstance)) //
+        Flux<ClientMessage> requestMessages = requests.asFlux().concatMap(it -> it);
+
+        return client.exchange(requestMessages, DoneToken::isDone) //
+            .filter(or(Prelogin.class::isInstance, SslState.class::isInstance, SspiToken.class::isInstance,
+                DoneToken.class::isInstance, ErrorToken.class::isInstance)) //
             .handle((message, sink) -> {
 
                 try {
@@ -91,7 +122,7 @@ final class LoginFlow {
                         }
 
                         if (!encryption.requiresSslHandshake()) {
-                            requests.emitNext(createLoginMessage(login, response), Sinks.EmitFailureHandler.FAIL_FAST);
+                            emitLoginRequest(requests, login, response, authentication);
                         }
 
                         return;
@@ -100,7 +131,25 @@ final class LoginFlow {
                     if (message instanceof SslState && message == SslState.NEGOTIATED) {
 
                         Prelogin prelogin = preloginResponse.get();
-                        requests.emitNext(createLoginMessage(login, prelogin), Sinks.EmitFailureHandler.FAIL_FAST);
+                        emitLoginRequest(requests, login, prelogin, authentication);
+                        return;
+                    }
+
+                    if (message instanceof SspiToken) {
+
+                        if (authentication == null) {
+                            throw ProtocolException.unsupported("Received an SSPI challenge without integrated authentication");
+                        }
+
+                        SspiToken token = (SspiToken) message;
+
+                        Mono<? extends ClientMessage> response = Mono.defer(() ->
+                                authentication.nextToken(token.getSspiBuffer()))
+                            .switchIfEmpty(Mono.error(new IllegalStateException(
+                                "Integrated authentication did not produce an SSPI response token")))
+                            .map(SspiMessage::create);
+
+                        requests.emitNext(response, Sinks.EmitFailureHandler.FAIL_FAST);
                         return;
                     }
 
@@ -125,12 +174,37 @@ final class LoginFlow {
             });
     }
 
+    private static void emitLoginRequest(Sinks.Many<Mono<? extends ClientMessage>> requests,
+                                         LoginConfiguration login, Prelogin prelogin,
+                                         @Nullable IntegratedAuthentication authentication) {
+
+        if (authentication == null) {
+            requests.emitNext(Mono.just(createLoginMessage(login, prelogin)), Sinks.EmitFailureHandler.FAIL_FAST);
+            return;
+        }
+
+        Mono<? extends ClientMessage> request = Mono.defer(authentication::initialToken)
+            .switchIfEmpty(Mono.error(new IllegalStateException(
+                "Integrated authentication did not produce an initial SSPI token")))
+            .map(sspiBuffer -> createLoginMessage(login, prelogin, sspiBuffer));
+
+        requests.emitNext(request, Sinks.EmitFailureHandler.FAIL_FAST);
+    }
+
     private static Login7 createLoginMessage(LoginConfiguration login, Prelogin prelogin) {
 
         Prelogin.Version serverVersion = prelogin.getRequiredToken(Prelogin.Version.class);
         TDSVersion tdsVersion = getTdsVersion(serverVersion.getVersion());
 
         return login.asBuilder().tdsVersion(tdsVersion).build();
+    }
+
+    private static Login7 createLoginMessage(LoginConfiguration login, Prelogin prelogin, byte[] sspiBuffer) {
+
+        Prelogin.Version serverVersion = prelogin.getRequiredToken(Prelogin.Version.class);
+        TDSVersion tdsVersion = getTdsVersion(serverVersion.getVersion());
+
+        return login.asBuilder().tdsVersion(tdsVersion).integratedSecurity(sspiBuffer).build();
     }
 
     private static TDSVersion getTdsVersion(int serverVersion) {

--- a/src/main/java/io/r2dbc/mssql/LoginFlow.java
+++ b/src/main/java/io/r2dbc/mssql/LoginFlow.java
@@ -145,8 +145,6 @@ final class LoginFlow {
 
                         Mono<? extends ClientMessage> response = Mono.defer(() ->
                                 authentication.nextToken(token.getSspiBuffer()))
-                            .switchIfEmpty(Mono.error(new IllegalStateException(
-                                "Integrated authentication did not produce an SSPI response token")))
                             .map(SspiMessage::create);
 
                         requests.emitNext(response, Sinks.EmitFailureHandler.FAIL_FAST);

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionConfiguration.java
@@ -87,6 +87,8 @@ public final class MssqlConnectionConfiguration {
 
     private final String hostNameInCertificate;
 
+    private final boolean integratedSecurity;
+
     private final CharSequence password;
 
     private final Predicate<String> preferCursoredExecution;
@@ -124,12 +126,13 @@ public final class MssqlConnectionConfiguration {
 
     private MssqlConnectionConfiguration(@Nullable String applicationName, @Nullable UUID connectionId, ConnectionProvider connectionProvider,
                                          Duration connectTimeout, @Nullable String database, String host, String hostNameInCertificate,
-                                         @Nullable Duration lockWaitTimeout, CharSequence password, Predicate<String> preferCursoredExecution,
+                                         boolean integratedSecurity, @Nullable Duration lockWaitTimeout, @Nullable CharSequence password,
+                                         Predicate<String> preferCursoredExecution,
                                          int port, boolean sendStringParametersAsUnicode, boolean ssl,
                                          Function<SslContextBuilder, SslContextBuilder> sslContextBuilderCustomizer,
                                          @Nullable Function<SslContextBuilder, SslContextBuilder> sslTunnelSslContextBuilderCustomizer,
                                          boolean tcpKeepAlive, boolean tcpNoDelay, boolean trustServerCertificate, @Nullable File trustStore,
-                                         @Nullable String trustStoreType, @Nullable char[] trustStorePassword, String username) {
+                                         @Nullable String trustStoreType, @Nullable char[] trustStorePassword, @Nullable String username) {
 
         this.applicationName = applicationName;
         this.connectionId = connectionId;
@@ -138,8 +141,9 @@ public final class MssqlConnectionConfiguration {
         this.database = database;
         this.host = Assert.requireNonNull(host, "host must not be null");
         this.hostNameInCertificate = Assert.requireNonNull(hostNameInCertificate, "hostNameInCertificate must not be null");
+        this.integratedSecurity = integratedSecurity;
         this.lockWaitTimeout = lockWaitTimeout;
-        this.password = Assert.requireNonNull(password, "password must not be null");
+        this.password = integratedSecurity && password == null ? "" : Assert.requireNonNull(password, "password must not be null");
         this.preferCursoredExecution = Assert.requireNonNull(preferCursoredExecution, "preferCursoredExecution must not be null");
         this.port = port;
         this.sendStringParametersAsUnicode = sendStringParametersAsUnicode;
@@ -152,7 +156,7 @@ public final class MssqlConnectionConfiguration {
         this.trustStore = trustStore;
         this.trustStoreType = trustStoreType;
         this.trustStorePassword = trustStorePassword;
-        this.username = Assert.requireNonNull(username, "username must not be null");
+        this.username = integratedSecurity && username == null ? "" : Assert.requireNonNull(username, "username must not be null");
     }
 
     /**
@@ -188,7 +192,7 @@ public final class MssqlConnectionConfiguration {
         }
 
         return new MssqlConnectionConfiguration(this.applicationName, this.connectionId, this.connectionProvider, this.connectTimeout, this.database, redirectServerName, hostNameInCertificate,
-            this.lockWaitTimeout,
+            this.integratedSecurity, this.lockWaitTimeout,
             this.password,
             this.preferCursoredExecution, redirect.getPort(), this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
             this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay, this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword, this.username
@@ -215,6 +219,7 @@ public final class MssqlConnectionConfiguration {
         sb.append(", database=\"").append(this.database).append('\"');
         sb.append(", host=\"").append(this.host).append('\"');
         sb.append(", hostNameInCertificate=\"").append(this.hostNameInCertificate).append('\"');
+        sb.append(", integratedSecurity=").append(this.integratedSecurity);
         sb.append(", lockWaitTimeout=\"").append(this.lockWaitTimeout).append('\"');
         sb.append(", password=\"").append(repeat(this.password.length(), "*")).append('\"');
         sb.append(", preferCursoredExecution=\"").append(this.preferCursoredExecution).append('\"');
@@ -258,6 +263,14 @@ public final class MssqlConnectionConfiguration {
 
     String getHostNameInCertificate() {
         return this.hostNameInCertificate;
+    }
+
+    boolean isIntegratedSecurity() {
+        return this.integratedSecurity;
+    }
+
+    String getServicePrincipalName() {
+        return String.format("MSSQLSvc/%s:%d", this.host, this.port);
     }
 
     @Nullable
@@ -361,6 +374,8 @@ public final class MssqlConnectionConfiguration {
         private String host;
 
         private String hostNameInCertificate;
+
+        private boolean integratedSecurity;
 
         @Nullable
         private Duration lockWaitTimeout;
@@ -510,6 +525,26 @@ public final class MssqlConnectionConfiguration {
          */
         public Builder host(String host) {
             this.host = Assert.requireNonNull(host, "host must not be null");
+            return this;
+        }
+
+        /**
+         * Enable Windows Integrated Security using the credentials of the current Windows process.
+         *
+         * @return this {@link Builder}
+         */
+        public Builder integratedSecurity() {
+            return integratedSecurity(true);
+        }
+
+        /**
+         * Configure Windows Integrated Security.
+         *
+         * @param integratedSecurity {@code true} to use the credentials of the current Windows process.
+         * @return this {@link Builder}
+         */
+        public Builder integratedSecurity(boolean integratedSecurity) {
+            this.integratedSecurity = integratedSecurity;
             return this;
         }
 
@@ -739,7 +774,7 @@ public final class MssqlConnectionConfiguration {
 
             return new MssqlConnectionConfiguration(this.applicationName, this.connectionId,
                 this.connectionProvider, this.connectTimeout, this.database, this.host, this.hostNameInCertificate,
-                this.lockWaitTimeout, this.password, this.preferCursoredExecution, this.port,
+                this.integratedSecurity, this.lockWaitTimeout, this.password, this.preferCursoredExecution, this.port,
                 this.sendStringParametersAsUnicode, this.ssl, this.sslContextBuilderCustomizer,
                 this.sslTunnelSslContextBuilderCustomizer, this.tcpKeepAlive, this.tcpNoDelay,
                 this.trustServerCertificate, this.trustStore, this.trustStoreType, this.trustStorePassword, this.username);

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionFactory.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionFactory.java
@@ -44,6 +44,8 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
 
     private final Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory;
 
+    private final Function<MssqlConnectionConfiguration, IntegratedAuthentication> integratedAuthenticationFactory;
+
     private final MssqlConnectionConfiguration configuration;
 
     private final DefaultCodecs codecs = new DefaultCodecs();
@@ -61,7 +63,16 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
     MssqlConnectionFactory(Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory,
                            MssqlConnectionConfiguration configuration) {
 
+        this(clientFactory, it -> new WindowsSspiAuthentication(it.getServicePrincipalName()), configuration);
+    }
+
+    MssqlConnectionFactory(Function<MssqlConnectionConfiguration, Mono<Client>> clientFactory,
+                           Function<MssqlConnectionConfiguration, IntegratedAuthentication> integratedAuthenticationFactory,
+                           MssqlConnectionConfiguration configuration) {
+
         this.clientFactory = Assert.requireNonNull(clientFactory, "clientFactory must not be null");
+        this.integratedAuthenticationFactory = Assert.requireNonNull(integratedAuthenticationFactory,
+            "integratedAuthenticationFactory must not be null");
         this.configuration = Assert.requireNonNull(configuration, "configuration must not be null");
     }
 
@@ -77,10 +88,8 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
 
     private Mono<Client> initializeClient(MssqlConnectionConfiguration configuration, boolean allowReroute) {
 
-        LoginConfiguration loginConfiguration = configuration.getLoginConfiguration();
-
         return this.clientFactory.apply(configuration)
-            .delayUntil(client -> LoginFlow.exchange(client, loginConfiguration)
+            .delayUntil(client -> login(client, configuration)
                 .onErrorResume(e -> propagateError(client.close(), e)))
             .flatMap(client -> {
                 return client.getRedirect().map(redirect -> {
@@ -98,6 +107,21 @@ public final class MssqlConnectionFactory implements ConnectionFactory {
         MssqlConnectionConfiguration routeConfiguration = this.configuration.withRedirect(redirect);
 
         return client.close().then(this.initializeClient(routeConfiguration, false));
+    }
+
+    private Mono<Void> login(Client client, MssqlConnectionConfiguration configuration) {
+
+        LoginConfiguration loginConfiguration = configuration.getLoginConfiguration();
+
+        return Mono.defer(() -> {
+
+            if (configuration.isIntegratedSecurity()) {
+                IntegratedAuthentication authentication = this.integratedAuthenticationFactory.apply(configuration);
+                return LoginFlow.exchange(client, loginConfiguration, authentication).then();
+            }
+
+            return LoginFlow.exchange(client, loginConfiguration).then();
+        });
     }
 
     private <T> Mono<T> propagateError(Mono<?> action, Throwable e) {

--- a/src/main/java/io/r2dbc/mssql/MssqlConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/mssql/MssqlConnectionFactoryProvider.java
@@ -66,6 +66,11 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<String> HOSTNAME_IN_CERTIFICATE = Option.valueOf("hostNameInCertificate");
 
     /**
+     * Enable Windows Integrated Security using the credentials of the current Windows process.
+     */
+    public static final Option<Boolean> INTEGRATED_SECURITY = Option.valueOf("integratedSecurity");
+
+    /**
      * Configure whether to prefer cursored execution on a statement-by-statement basis. Value can be {@link Boolean}, a {@link Predicate}, or a {@link Class class name}. The {@link Predicate}
      * accepts the SQL query string and returns a boolean flag indicating preference.
      * {@code true} prefers cursors, {@code false} prefers direct execution.
@@ -155,6 +160,11 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
 
         OptionMapper mapper = OptionMapper.create(connectionFactoryOptions);
 
+        boolean integratedSecurity = connectionFactoryOptions.hasOption(INTEGRATED_SECURITY) &&
+            OptionMapper.toBoolean(connectionFactoryOptions.getRequiredValue(INTEGRATED_SECURITY));
+
+        builder.integratedSecurity(integratedSecurity);
+
         mapper.fromTyped(APPLICATION_NAME).to(builder::applicationName);
         mapper.from(CONNECTION_ID).map(OptionMapper::toUuid).to(builder::connectionId);
         mapper.fromTyped(CONNECTION_PROVIDER).to(builder::connectionProvider);
@@ -198,8 +208,11 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
         mapper.from(TRUST_STORE_PASSWORD).map(it -> it instanceof String ? ((String) it).toCharArray() : (char[]) it).to(builder::trustStorePassword);
 
         builder.host(connectionFactoryOptions.getRequiredValue(HOST).toString());
-        builder.password((CharSequence) connectionFactoryOptions.getRequiredValue(PASSWORD));
-        builder.username(connectionFactoryOptions.getRequiredValue(USER).toString());
+
+        if (!integratedSecurity) {
+            builder.password((CharSequence) connectionFactoryOptions.getRequiredValue(PASSWORD));
+            builder.username(connectionFactoryOptions.getRequiredValue(USER).toString());
+        }
 
         MssqlConnectionConfiguration configuration = builder.build();
         if (this.logger.isDebugEnabled()) {
@@ -220,6 +233,16 @@ public final class MssqlConnectionFactoryProvider implements ConnectionFactoryPr
 
         if (!connectionFactoryOptions.hasOption(HOST)) {
             return false;
+        }
+
+        if (connectionFactoryOptions.hasOption(INTEGRATED_SECURITY)) {
+            try {
+                if (OptionMapper.toBoolean(connectionFactoryOptions.getRequiredValue(INTEGRATED_SECURITY))) {
+                    return true;
+                }
+            } catch (IllegalArgumentException e) {
+                return false;
+            }
         }
 
         if (!connectionFactoryOptions.hasOption(PASSWORD)) {

--- a/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
+++ b/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
@@ -105,6 +105,7 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
         return Mono.fromRunnable(this::releaseResources).subscribeOn(this.scheduler).then();
     }
 
+    @Nullable
     private synchronized byte[] createToken(@Nullable byte[] inputToken, boolean initial) {
 
         Assert.state(!this.closed, "Integrated authentication is already closed");
@@ -151,6 +152,10 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
 
         if (initial && (token == null || token.length == 0)) {
             throw new IllegalStateException("InitializeSecurityContext did not produce an initial SSPI token");
+        }
+
+        if (!initial && status == W32Errors.SEC_E_OK && (token == null || token.length == 0)) {
+            return null;
         }
 
         return token == null ? new byte[0] : token;

--- a/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
+++ b/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
@@ -19,6 +19,7 @@ package io.r2dbc.mssql;
 import com.sun.jna.Platform;
 import com.sun.jna.platform.win32.Secur32;
 import com.sun.jna.platform.win32.Sspi;
+import com.sun.jna.platform.win32.Sspi.PSecPkgInfo;
 import com.sun.jna.platform.win32.Sspi.CredHandle;
 import com.sun.jna.platform.win32.Sspi.CtxtHandle;
 import com.sun.jna.platform.win32.Sspi.TimeStamp;
@@ -43,7 +44,7 @@ import java.util.Arrays;
  */
 final class WindowsSspiAuthentication implements IntegratedAuthentication {
 
-    private static final int MAX_TOKEN_SIZE = 65536;
+    private static final String SECURITY_PACKAGE = "Negotiate";
 
     private static final int SEC_I_COMPLETE_NEEDED = 0x00090313;
 
@@ -54,6 +55,8 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
     private final SspiSupport sspi;
 
     private final Scheduler scheduler;
+
+    private int maxTokenSize;
 
     private final CredHandle credentials = new CredHandle();
 
@@ -112,6 +115,9 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
 
         if (initial) {
             Assert.state(!this.started, "Initial SSPI token has already been created");
+            this.maxTokenSize = this.sspi.queryMaxTokenSize();
+            Assert.state(this.maxTokenSize > 0,
+                "Negotiate security package must report a positive maximum token size");
             acquireCredentials();
             this.started = true;
         } else {
@@ -122,7 +128,7 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
         ManagedSecBufferDesc input = inputToken == null
             ? null
             : new ManagedSecBufferDesc(Sspi.SECBUFFER_TOKEN, inputToken);
-        ManagedSecBufferDesc output = new ManagedSecBufferDesc(Sspi.SECBUFFER_TOKEN, MAX_TOKEN_SIZE);
+        ManagedSecBufferDesc output = new ManagedSecBufferDesc(Sspi.SECBUFFER_TOKEN, this.maxTokenSize);
 
         int status = this.sspi.initializeSecurityContext(this.credentials,
             this.contextAcquired ? this.context : null, this.targetName, input, this.context, output,
@@ -226,6 +232,8 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
 
     interface SspiSupport {
 
+        int queryMaxTokenSize();
+
         int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry);
 
         int initializeSecurityContext(CredHandle credentials, @Nullable CtxtHandle context, String targetName,
@@ -249,8 +257,37 @@ final class WindowsSspiAuthentication implements IntegratedAuthentication {
         }
 
         @Override
+        public int queryMaxTokenSize() {
+
+            PSecPkgInfo packageInfo = new PSecPkgInfo();
+            int status = this.secur32.QuerySecurityPackageInfo(SECURITY_PACKAGE, packageInfo);
+
+            if (status != W32Errors.SEC_E_OK) {
+                throw sspiFailure("QuerySecurityPackageInfo", status);
+            }
+
+            try {
+
+                if (packageInfo.pPkgInfo == null) {
+                    throw new IllegalStateException(
+                        "QuerySecurityPackageInfo did not return security package information");
+                }
+
+                return packageInfo.pPkgInfo.cbMaxToken;
+            } finally {
+
+                if (packageInfo.pPkgInfo != null) {
+                    int freeStatus = this.secur32.FreeContextBuffer(packageInfo.pPkgInfo.getPointer());
+
+                    if (freeStatus != W32Errors.SEC_E_OK) {
+                        throw sspiFailure("FreeContextBuffer", freeStatus);
+                    }
+                }
+            }
+        }
+        @Override
         public int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry) {
-            return this.secur32.AcquireCredentialsHandle(null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND,
+            return this.secur32.AcquireCredentialsHandle(null, SECURITY_PACKAGE, Sspi.SECPKG_CRED_OUTBOUND,
                 null, null, null, null, credentials, expiry);
         }
 

--- a/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
+++ b/src/main/java/io/r2dbc/mssql/WindowsSspiAuthentication.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import com.sun.jna.Platform;
+import com.sun.jna.platform.win32.Secur32;
+import com.sun.jna.platform.win32.Sspi;
+import com.sun.jna.platform.win32.Sspi.CredHandle;
+import com.sun.jna.platform.win32.Sspi.CtxtHandle;
+import com.sun.jna.platform.win32.Sspi.TimeStamp;
+import com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.ptr.IntByReference;
+import io.r2dbc.mssql.util.Assert;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.annotation.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Windows SSPI implementation of {@link IntegratedAuthentication}.
+ *
+ * Uses the credentials of the current Windows process and the Negotiate security package so Windows can select
+ * Kerberos or NTLM as appropriate.
+ *
+ * @author Daniel Pachali
+ */
+final class WindowsSspiAuthentication implements IntegratedAuthentication {
+
+    private static final int MAX_TOKEN_SIZE = 65536;
+
+    private static final int SEC_I_COMPLETE_NEEDED = 0x00090313;
+
+    private static final int SEC_I_COMPLETE_AND_CONTINUE = 0x00090314;
+
+    private final String targetName;
+
+    private final SspiSupport sspi;
+
+    private final Scheduler scheduler;
+
+    private final CredHandle credentials = new CredHandle();
+
+    private final CtxtHandle context = new CtxtHandle();
+
+    private boolean credentialsAcquired;
+
+    private boolean contextAcquired;
+
+    private boolean started;
+
+    private boolean closed;
+
+    /**
+     * Create Windows integrated authentication for a service principal name.
+     *
+     * @param targetName the target service principal name, for example {@code MSSQLSvc/sql.example.com:1433}.
+     */
+    WindowsSspiAuthentication(String targetName) {
+        this(targetName, createNativeSupport(), Schedulers.boundedElastic());
+    }
+
+    WindowsSspiAuthentication(String targetName, SspiSupport sspi, Scheduler scheduler) {
+
+        this.targetName = Assert.requireNonNull(targetName, "Target name must not be null");
+        Assert.isTrue(targetName.trim().length() > 0, "Target name must not be empty");
+
+        this.sspi = Assert.requireNonNull(sspi, "SSPI support must not be null");
+        this.scheduler = Assert.requireNonNull(scheduler, "Scheduler must not be null");
+    }
+
+    @Override
+    public Mono<byte[]> initialToken() {
+        return Mono.fromCallable(() -> createToken(null, true)).subscribeOn(this.scheduler);
+    }
+
+    @Override
+    public Mono<byte[]> nextToken(byte[] serverToken) {
+
+        Assert.requireNonNull(serverToken, "Server SSPI token must not be null");
+
+        byte[] token = Arrays.copyOf(serverToken, serverToken.length);
+
+        return Mono.fromCallable(() -> createToken(token, false)).subscribeOn(this.scheduler);
+    }
+
+    @Override
+    public Mono<Void> close() {
+        return Mono.fromRunnable(this::releaseResources).subscribeOn(this.scheduler).then();
+    }
+
+    private synchronized byte[] createToken(@Nullable byte[] inputToken, boolean initial) {
+
+        Assert.state(!this.closed, "Integrated authentication is already closed");
+
+        if (initial) {
+            Assert.state(!this.started, "Initial SSPI token has already been created");
+            acquireCredentials();
+            this.started = true;
+        } else {
+            Assert.state(this.started, "Initial SSPI token has not been created");
+            Assert.state(this.contextAcquired, "SSPI security context has not been created");
+        }
+
+        ManagedSecBufferDesc input = inputToken == null
+            ? null
+            : new ManagedSecBufferDesc(Sspi.SECBUFFER_TOKEN, inputToken);
+        ManagedSecBufferDesc output = new ManagedSecBufferDesc(Sspi.SECBUFFER_TOKEN, MAX_TOKEN_SIZE);
+
+        int status = this.sspi.initializeSecurityContext(this.credentials,
+            this.contextAcquired ? this.context : null, this.targetName, input, this.context, output,
+            new IntByReference());
+
+        if (!this.context.isNull()) {
+            this.contextAcquired = true;
+        }
+
+        if (status == SEC_I_COMPLETE_NEEDED || status == SEC_I_COMPLETE_AND_CONTINUE) {
+
+            int completeStatus = this.sspi.completeAuthToken(this.context, output);
+
+            if (completeStatus != W32Errors.SEC_E_OK) {
+                throw sspiFailure("CompleteAuthToken", completeStatus);
+            }
+        }
+
+        if (status != W32Errors.SEC_E_OK &&
+            status != W32Errors.SEC_I_CONTINUE_NEEDED &&
+            status != SEC_I_COMPLETE_NEEDED &&
+            status != SEC_I_COMPLETE_AND_CONTINUE) {
+            throw sspiFailure("InitializeSecurityContext", status);
+        }
+
+        byte[] token = output.getBuffer(0).getBytes();
+
+        if (initial && (token == null || token.length == 0)) {
+            throw new IllegalStateException("InitializeSecurityContext did not produce an initial SSPI token");
+        }
+
+        return token == null ? new byte[0] : token;
+    }
+
+    private void acquireCredentials() {
+
+        TimeStamp expiry = new TimeStamp();
+
+        int status = this.sspi.acquireCredentialsHandle(this.credentials, expiry);
+
+        if (status != W32Errors.SEC_E_OK) {
+            throw sspiFailure("AcquireCredentialsHandle", status);
+        }
+
+        this.credentialsAcquired = true;
+    }
+
+    private synchronized void releaseResources() {
+
+        if (this.closed) {
+            return;
+        }
+
+        this.closed = true;
+
+        RuntimeException failure = null;
+
+        if (this.contextAcquired && !this.context.isNull()) {
+
+            int status = this.sspi.deleteSecurityContext(this.context);
+
+            if (status != W32Errors.SEC_E_OK) {
+                failure = sspiFailure("DeleteSecurityContext", status);
+            }
+
+            this.contextAcquired = false;
+        }
+
+        if (this.credentialsAcquired && !this.credentials.isNull()) {
+
+            int status = this.sspi.freeCredentialsHandle(this.credentials);
+
+            if (status != W32Errors.SEC_E_OK && failure == null) {
+                failure = sspiFailure("FreeCredentialsHandle", status);
+            }
+
+            this.credentialsAcquired = false;
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static SspiSupport createNativeSupport() {
+
+        if (!Platform.isWindows()) {
+            throw new IllegalStateException("Windows integrated authentication is only supported on Windows");
+        }
+
+        return new NativeSspiSupport(Secur32.INSTANCE);
+    }
+
+    private static IllegalStateException sspiFailure(String operation, int status) {
+        return new IllegalStateException(String.format("%s failed with SSPI status 0x%08X", operation, status));
+    }
+
+    interface SspiSupport {
+
+        int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry);
+
+        int initializeSecurityContext(CredHandle credentials, @Nullable CtxtHandle context, String targetName,
+                                      @Nullable ManagedSecBufferDesc input, CtxtHandle newContext,
+                                      ManagedSecBufferDesc output, IntByReference contextAttributes);
+
+        int completeAuthToken(CtxtHandle context, ManagedSecBufferDesc token);
+
+        int deleteSecurityContext(CtxtHandle context);
+
+        int freeCredentialsHandle(CredHandle credentials);
+
+    }
+
+    private static final class NativeSspiSupport implements SspiSupport {
+
+        private final Secur32 secur32;
+
+        private NativeSspiSupport(Secur32 secur32) {
+            this.secur32 = secur32;
+        }
+
+        @Override
+        public int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry) {
+            return this.secur32.AcquireCredentialsHandle(null, "Negotiate", Sspi.SECPKG_CRED_OUTBOUND,
+                null, null, null, null, credentials, expiry);
+        }
+
+        @Override
+        public int initializeSecurityContext(CredHandle credentials, @Nullable CtxtHandle context, String targetName,
+                                             @Nullable ManagedSecBufferDesc input, CtxtHandle newContext,
+                                             ManagedSecBufferDesc output, IntByReference contextAttributes) {
+
+            return this.secur32.InitializeSecurityContext(credentials, context, targetName, Sspi.ISC_REQ_CONNECTION,
+                0, Sspi.SECURITY_NATIVE_DREP, input, 0, newContext, output, contextAttributes, null);
+        }
+
+        @Override
+        public int completeAuthToken(CtxtHandle context, ManagedSecBufferDesc token) {
+            return this.secur32.CompleteAuthToken(context, token);
+        }
+
+        @Override
+        public int deleteSecurityContext(CtxtHandle context) {
+            return this.secur32.DeleteSecurityContext(context);
+        }
+
+        @Override
+        public int freeCredentialsHandle(CredHandle credentials) {
+            return this.secur32.FreeCredentialsHandle(credentials);
+        }
+
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/message/token/Login7.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/Login7.java
@@ -47,6 +47,8 @@ public final class Login7 implements TokenStream, ClientMessage {
 
     private static final short TDS_LOGIN_REQUEST_BASE_LEN = 94;
 
+    private static final int USHORT_MAX = 0xFFFF;
+
     private static final HeaderOptions header = HeaderOptions.create(Type.TDS7_LOGIN, Status.empty());
 
     private final int estimatedPacketLength;
@@ -95,11 +97,13 @@ public final class Login7 implements TokenStream, ClientMessage {
 
     private final byte[] clientId;
 
+    private final byte[] sspiBuffer;
+
     private final ConditionalProtocolSegment passwordChange;
 
     private Login7(TDSVersion tdsVersion, int packetSize, byte[] clientProgVer, int clientPid, int connectionId,
                    OptionFlags1 optionFlags1, OptionFlags2 optionFlags2, TypeFlags typeFlags, OptionFlags3 optionFlags3,
-                   Collection<LoginRequestToken> tokens, byte[] clientId) {
+                   Collection<LoginRequestToken> tokens, byte[] clientId, byte[] sspiBuffer) {
 
         this.tdsVersion = tdsVersion;
         this.packetSize = packetSize;
@@ -113,6 +117,12 @@ public final class Login7 implements TokenStream, ClientMessage {
         this.tokens = tokens;
         this.clientId = clientId;
 
+        Assert.requireNonNull(sspiBuffer, "SSPI buffer must not be null");
+        Assert.isTrue(sspiBuffer.length <= USHORT_MAX || tdsVersion.isGreateOrEqualsTo(TDSVersion.VER_YUKON),
+            "SSPI buffers larger than 65535 bytes require TDS 7.2 or later");
+
+        this.sspiBuffer = Arrays.copyOf(sspiBuffer, sspiBuffer.length);
+
         int baseLength = TDS_LOGIN_REQUEST_BASE_LEN;
 
         EnumSet<TokenType> lengthRelevant = EnumSet.of(TokenType.Hostname, TokenType.AppName, TokenType.Servername,
@@ -125,6 +135,7 @@ public final class Login7 implements TokenStream, ClientMessage {
         }
 
         baseLength += getToken(TokenType.Password).getEncrypted().length;
+        baseLength += this.sspiBuffer.length;
 
         ConditionalProtocolSegment passwordChange = Conditionals.DISABLED;
 
@@ -217,16 +228,21 @@ public final class Login7 implements TokenStream, ClientMessage {
 
         buffer.writeBytes(this.clientId);
 
-        // SSPI/Integrated security disabled.
-        buffer.writeShort(0);
-        buffer.writeShort(0);
+        if (this.sspiBuffer.length > 0) {
+            buffer.writeShortLE(TDS_LOGIN_REQUEST_BASE_LEN + dataLen);
+            buffer.writeShortLE(Math.min(this.sspiBuffer.length, USHORT_MAX));
+            dataLen += this.sspiBuffer.length;
+        } else {
+            buffer.writeShort(0);
+            buffer.writeShort(0);
+        }
 
         // Database to attach during connection process
         buffer.writeShort(0);
         buffer.writeShort(0);
 
-        // TDS 7.2: Password change
-        this.passwordChange.encode(buffer);
+        // TDS 7.2: Password change and cbSSPILong
+        this.passwordChange.encode(buffer, this.sspiBuffer.length);
 
         buffer.writeBytes(hostname.getValue());
         buffer.writeBytes(username.getValue());
@@ -239,6 +255,7 @@ public final class Login7 implements TokenStream, ClientMessage {
 
         buffer.writeBytes(intName.getValue());
         buffer.writeBytes(database.getValue());
+        buffer.writeBytes(this.sspiBuffer);
 
         // AE
         buffer.writeByte(4);
@@ -330,6 +347,9 @@ public final class Login7 implements TokenStream, ClientMessage {
 
         @Nullable
         private CharSequence password;
+
+        @Nullable
+        private byte[] sspiBuffer;
 
         @Nullable
         private CharSequence applicationName;
@@ -463,6 +483,23 @@ public final class Login7 implements TokenStream, ClientMessage {
         }
 
         /**
+         * Configure integrated security using the initial SSPI/SPNEGO token.
+         * Username and password fields are omitted from LOGIN7 when integrated security is configured.
+         *
+         * @param sspiBuffer the initial SSPI/SPNEGO token.
+         * @return {@code this} {@link Builder}.
+         * @throws IllegalArgumentException when {@code sspiBuffer} is {@code null} or empty.
+         */
+        public Builder integratedSecurity(byte[] sspiBuffer) {
+
+            Assert.requireNonNull(sspiBuffer, "SSPI buffer must not be null");
+            Assert.isTrue(sspiBuffer.length > 0, "SSPI buffer must not be empty");
+
+            this.sspiBuffer = Arrays.copyOf(sspiBuffer, sspiBuffer.length);
+            return this;
+        }
+
+        /**
          * Configure the application name. Must not exceed 128 chars.
          *
          * @param applicationName the application name.
@@ -588,18 +625,24 @@ public final class Login7 implements TokenStream, ClientMessage {
          * Build a new {@link Login7} message.
          *
          * @return a new {@link Login7} message.
-         * @throws IllegalStateException if {@code username}, {@code password}, or {@code databaseName} is {@code null} (unconfigured).
+         * @throws IllegalStateException if {@code databaseName} is {@code null}, or if {@code username} or {@code password}
+         * is {@code null} when integrated security is not configured.
          */
         public Login7 build() {
 
-            Assert.state(this.username != null, "Username must not be null");
-            Assert.state(this.password != null, "Password must not be null");
+            boolean integratedSecurity = this.sspiBuffer != null;
+
+            if (!integratedSecurity) {
+                Assert.state(this.username != null, "Username must not be null");
+                Assert.state(this.password != null, "Password must not be null");
+            }
+
             Assert.state(this.databaseName != null, "Database must not be null");
 
             List<LoginRequestToken> requestTokens = new ArrayList<>();
             requestTokens.add(new LoginRequestToken(TokenType.Hostname, this.hostname));
-            requestTokens.add(new LoginRequestToken(TokenType.Username, this.username));
-            requestTokens.add(new LoginRequestToken(TokenType.Password, this.password));
+            requestTokens.add(new LoginRequestToken(TokenType.Username, integratedSecurity ? null : this.username));
+            requestTokens.add(new LoginRequestToken(TokenType.Password, integratedSecurity ? null : this.password));
             requestTokens.add(new LoginRequestToken(TokenType.AppName, this.applicationName));
             requestTokens.add(new LoginRequestToken(TokenType.Servername, this.serverName));
             requestTokens.add(new LoginRequestToken(TokenType.IntName, this.clientLibraryName));
@@ -612,8 +655,15 @@ public final class Login7 implements TokenStream, ClientMessage {
                     (byte) this.clientLibraryVersion.getMinor(), (byte) this.clientLibraryVersion.getMajor()};
             }
 
+            OptionFlags2 optionFlags2 = integratedSecurity
+                ? this.optionFlags2.enableIntegratedSecurity()
+                : this.optionFlags2;
+
+            byte[] sspiBuffer = integratedSecurity ? this.sspiBuffer : new byte[0];
+
             return new Login7(this.tdsVersion, this.packetSize, interfaceLibVersion, this.clientPid, this.connectionId,
-                this.optionFlags1, this.optionFlags2, this.typeFlags, this.optionFlags3, requestTokens, this.clientId);
+                this.optionFlags1, optionFlags2, this.typeFlags, this.optionFlags3, requestTokens, this.clientId,
+                sspiBuffer);
 
         }
 
@@ -1289,9 +1339,10 @@ public final class Login7 implements TokenStream, ClientMessage {
         /**
          * Encode the segment onto the {@link ByteBuf}.
          *
-         * @param buffer the target {@link ByteBuf}.
+         * @param buffer     the target {@link ByteBuf}.
+         * @param sspiLength the SSPI payload length.
          */
-        void encode(ByteBuf buffer);
+        void encode(ByteBuf buffer, int sspiLength);
 
     }
 
@@ -1312,10 +1363,10 @@ public final class Login7 implements TokenStream, ClientMessage {
             }
 
             @Override
-            public void encode(ByteBuf buffer) {
+            public void encode(ByteBuf buffer, int sspiLength) {
                 buffer.writeShort((short) 0);
                 buffer.writeShort((short) 0);
-                buffer.writeInt((short) 0);
+                buffer.writeIntLE(sspiLength > USHORT_MAX ? sspiLength : 0);
             }
         };
 
@@ -1325,7 +1376,7 @@ public final class Login7 implements TokenStream, ClientMessage {
         }
 
         @Override
-        public void encode(ByteBuf buffer) {
+        public void encode(ByteBuf buffer, int sspiLength) {
         }
     }
 

--- a/src/main/java/io/r2dbc/mssql/message/token/SspiMessage.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/SspiMessage.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.message.token;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.mssql.message.ClientMessage;
+import io.r2dbc.mssql.message.header.HeaderOptions;
+import io.r2dbc.mssql.message.header.Status;
+import io.r2dbc.mssql.message.header.Type;
+import io.r2dbc.mssql.message.tds.TdsFragment;
+import io.r2dbc.mssql.message.tds.TdsPackets;
+import io.r2dbc.mssql.util.Assert;
+
+/**
+ * SSPI message sent by the client during integrated authentication.
+ *
+ * @author Daniel Pachali
+ */
+public final class SspiMessage implements ClientMessage, TokenStream {
+
+    private static final HeaderOptions HEADER = HeaderOptions.create(Type.SSPI, Status.empty());
+
+    private final byte[] sspiBuffer;
+
+    private SspiMessage(byte[] sspiBuffer) {
+        this.sspiBuffer = Assert.requireNonNull(sspiBuffer, "SSPI buffer must not be null");
+    }
+
+    /**
+     * Creates a new {@link SspiMessage}.
+     *
+     * @param sspiBuffer the SSPI/SPNEGO authentication token.
+     * @return the {@link SspiMessage}.
+     */
+    public static SspiMessage create(byte[] sspiBuffer) {
+        return new SspiMessage(sspiBuffer);
+    }
+
+    @Override
+    public TdsFragment encode(ByteBufAllocator allocator, int packetSize) {
+
+        Assert.requireNonNull(allocator, "ByteBufAllocator must not be null");
+
+        ByteBuf buffer = allocator.buffer(this.sspiBuffer.length);
+        buffer.writeBytes(this.sspiBuffer);
+
+        return TdsPackets.create(HEADER, buffer);
+    }
+
+    @Override
+    public String getName() {
+        return "SSPI";
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer();
+        sb.append(getClass().getSimpleName());
+        sb.append(" [length=").append(this.sspiBuffer.length);
+        sb.append(']');
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/message/token/SspiToken.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/SspiToken.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.message.token;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.message.tds.Decode;
+import io.r2dbc.mssql.util.Assert;
+
+/**
+ * SSPI token returned by the server during the login process.
+ *
+ * @author Daniel Pachali
+ */
+public final class SspiToken extends AbstractDataToken {
+
+    public static final byte TYPE = (byte) 0xED;
+
+    private final byte[] sspiBuffer;
+
+    private SspiToken(byte[] sspiBuffer) {
+
+        super(TYPE);
+        this.sspiBuffer = Assert.requireNonNull(sspiBuffer, "SSPI buffer must not be null");
+    }
+
+    /**
+     * Decode a {@link SspiToken}.
+     *
+     * @param buffer the data buffer.
+     * @return the decoded {@link SspiToken}.
+     */
+    public static SspiToken decode(ByteBuf buffer) {
+
+        Assert.requireNonNull(buffer, "Data buffer must not be null");
+
+        int length = Decode.uShort(buffer);
+        byte[] sspiBuffer = new byte[length];
+
+        buffer.readBytes(sspiBuffer);
+
+        return new SspiToken(sspiBuffer);
+    }
+
+    /**
+     * Check whether the {@link ByteBuf} can be decoded into an entire {@link SspiToken}.
+     *
+     * @param buffer the data buffer.
+     * @return {@code true} if the buffer contains sufficient data to entirely decode {@link SspiToken}.
+     */
+    public static boolean canDecode(ByteBuf buffer) {
+
+        Assert.requireNonNull(buffer, "Data buffer must not be null");
+
+        Integer length = Decode.peekUShort(buffer);
+
+        return length != null && buffer.readableBytes() >= length + /* length field */ 2;
+    }
+
+    public byte[] getSspiBuffer() {
+        return this.sspiBuffer;
+    }
+
+    @Override
+    public String getName() {
+        return "SSPI";
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer();
+        sb.append(getClass().getSimpleName());
+        sb.append(" [length=").append(this.sspiBuffer.length);
+        sb.append(']');
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/io/r2dbc/mssql/message/token/Tabular.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/Tabular.java
@@ -115,6 +115,10 @@ public final class Tabular implements Message {
                 return LoginAckToken.decode(buffer);
             }
 
+            if (type == SspiToken.TYPE) {
+                return SspiToken.canDecode(buffer) ? SspiToken.decode(buffer) : DecodeFinished.UNABLE_TO_DECODE;
+            }
+
             if (type == ColumnMetadataToken.TYPE) {
 
                 if (!ColumnMetadataToken.canDecode(buffer, encryptionSupported)) {

--- a/src/test/java/io/r2dbc/mssql/LoginFlowUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/LoginFlowUnitTests.java
@@ -198,6 +198,77 @@ class LoginFlowUnitTests {
         assertThat(closed).isTrue();
     }
 
+    @Test
+    void shouldCompleteIntegratedAuthenticationWithoutFinalClientToken() {
+
+        List<Prelogin.Token> tokens = new ArrayList<>();
+
+        tokens.add(new Prelogin.Version(14, 0));
+        tokens.add(new Prelogin.Encryption(Prelogin.Encryption.ENCRYPT_NOT_SUP));
+        tokens.add(Prelogin.Terminator.INSTANCE);
+        Prelogin preloginResponse = new Prelogin(tokens);
+
+        byte[] initialToken = new byte[]{0x60, 0x01, 0x02};
+        byte[] challenge = new byte[]{0x11, 0x12};
+        byte[] response = new byte[]{0x21, 0x22, 0x23};
+        byte[] finalServerToken = new byte[]{0x31, 0x32, 0x33};
+
+        SspiToken serverChallenge = sspiToken(challenge);
+        SspiToken serverFinalToken = sspiToken(finalServerToken);
+
+        AtomicInteger round = new AtomicInteger();
+        AtomicBoolean closed = new AtomicBoolean();
+
+        IntegratedAuthentication authentication = new IntegratedAuthentication() {
+
+            @Override
+            public Mono<byte[]> initialToken() {
+                return Mono.just(initialToken);
+            }
+
+            @Override
+            public Mono<byte[]> nextToken(byte[] serverToken) {
+
+                int currentRound = round.getAndIncrement();
+
+                if (currentRound == 0) {
+                    assertThat(serverToken).containsExactly(challenge);
+                    return Mono.just(response);
+                }
+
+                assertThat(currentRound).isEqualTo(1);
+                assertThat(serverToken).containsExactly(finalServerToken);
+                return Mono.empty();
+            }
+
+            @Override
+            public Mono<Void> close() {
+                return Mono.fromRunnable(() -> closed.set(true));
+            }
+        };
+
+        TestClient client = TestClient.builder()
+            .window()
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(Prelogin.class))
+            .thenRespond(preloginResponse)
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(Login7.class))
+            .thenRespond(serverChallenge)
+            .assertNextRequestWith(actual -> assertSspiMessage(actual, response))
+            .thenRespond(serverFinalToken, DoneToken.create(0))
+            .done()
+            .build();
+
+        LoginConfiguration login = new LoginConfiguration("app", null, "db", "host", "bar", "server", false, "foo");
+
+        LoginFlow.exchange(client, login, authentication)
+            .as(StepVerifier::create)
+            .expectNext(DoneToken.create(0))
+            .verifyComplete();
+
+        assertThat(round).hasValue(2);
+        assertThat(closed).isTrue();
+    }
+
     private static SspiToken sspiToken(byte[] payload) {
 
         ByteBuf buffer = Unpooled.buffer(payload.length + 2);

--- a/src/test/java/io/r2dbc/mssql/LoginFlowUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/LoginFlowUnitTests.java
@@ -16,17 +16,28 @@
 
 package io.r2dbc.mssql;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.r2dbc.mssql.client.TestClient;
+import io.r2dbc.mssql.message.tds.ContextualTdsFragment;
 import io.r2dbc.mssql.message.tds.ProtocolException;
 import io.r2dbc.mssql.message.token.DoneToken;
 import io.r2dbc.mssql.message.token.ErrorToken;
+import io.r2dbc.mssql.message.token.Login7;
 import io.r2dbc.mssql.message.token.Prelogin;
+import io.r2dbc.mssql.message.token.SspiMessage;
+import io.r2dbc.mssql.message.token.SspiToken;
+import io.r2dbc.mssql.util.TestByteBufAllocator;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -97,6 +108,113 @@ class LoginFlowUnitTests {
             .as(StepVerifier::create)
             .expectError(ProtocolException.class)
             .verify();
+    }
+
+
+    @Test
+    void shouldNegotiateIntegratedAuthenticationReactively() {
+
+        List<Prelogin.Token> tokens = new ArrayList<>();
+
+        tokens.add(new Prelogin.Version(14, 0));
+        tokens.add(new Prelogin.Encryption(Prelogin.Encryption.ENCRYPT_NOT_SUP));
+        tokens.add(Prelogin.Terminator.INSTANCE);
+        Prelogin preloginResponse = new Prelogin(tokens);
+
+        byte[] initialToken = new byte[]{0x60, 0x01, 0x02};
+        byte[] challenge1 = new byte[]{0x11, 0x12};
+        byte[] response1 = new byte[]{0x21, 0x22, 0x23};
+        byte[] challenge2 = new byte[]{0x31, 0x32, 0x33};
+        byte[] response2 = new byte[]{0x41, 0x42};
+
+        SspiToken serverChallenge1 = sspiToken(challenge1);
+        SspiToken serverChallenge2 = sspiToken(challenge2);
+
+        AtomicInteger round = new AtomicInteger();
+        AtomicBoolean closed = new AtomicBoolean();
+
+        IntegratedAuthentication authentication = new IntegratedAuthentication() {
+
+            @Override
+            public Mono<byte[]> initialToken() {
+                return Mono.just(initialToken);
+            }
+
+            @Override
+            public Mono<byte[]> nextToken(byte[] serverToken) {
+
+                int currentRound = round.getAndIncrement();
+
+                if (currentRound == 0) {
+                    assertThat(serverToken).containsExactly(challenge1);
+                    return Mono.just(response1);
+                }
+
+                assertThat(currentRound).isEqualTo(1);
+                assertThat(serverToken).containsExactly(challenge2);
+                return Mono.just(response2);
+            }
+
+            @Override
+            public Mono<Void> close() {
+                return Mono.fromRunnable(() -> closed.set(true));
+            }
+        };
+
+        TestClient client = TestClient.builder()
+            .window()
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(Prelogin.class))
+            .thenRespond(preloginResponse)
+            .assertNextRequestWith(actual -> {
+                assertThat(actual).isInstanceOf(Login7.class);
+
+                ContextualTdsFragment fragment =
+                    (ContextualTdsFragment) ((Login7) actual).encode(TestByteBufAllocator.TEST, 0);
+                ByteBuf buffer = fragment.getByteBuf();
+
+                assertThat(buffer.getUnsignedByte(25) & 0x80).isEqualTo(0x80);
+
+                int sspiOffset = buffer.getUnsignedShortLE(78);
+                int sspiLength = buffer.getUnsignedShortLE(80);
+
+                assertThat(ByteBufUtil.getBytes(buffer, sspiOffset, sspiLength)).containsExactly(initialToken);
+            })
+            .thenRespond(serverChallenge1)
+            .assertNextRequestWith(actual -> assertSspiMessage(actual, response1))
+            .thenRespond(serverChallenge2)
+            .assertNextRequestWith(actual -> assertSspiMessage(actual, response2))
+            .thenRespond(DoneToken.create(0))
+            .done()
+            .build();
+
+        LoginConfiguration login = new LoginConfiguration("app", null, "db", "host", "bar", "server", false, "foo");
+
+        LoginFlow.exchange(client, login, authentication)
+            .as(StepVerifier::create)
+            .expectNext(DoneToken.create(0))
+            .verifyComplete();
+
+        assertThat(round).hasValue(2);
+        assertThat(closed).isTrue();
+    }
+
+    private static SspiToken sspiToken(byte[] payload) {
+
+        ByteBuf buffer = Unpooled.buffer(payload.length + 2);
+        buffer.writeShortLE(payload.length);
+        buffer.writeBytes(payload);
+
+        return SspiToken.decode(buffer);
+    }
+
+    private static void assertSspiMessage(Object actual, byte[] expectedPayload) {
+
+        assertThat(actual).isInstanceOf(SspiMessage.class);
+
+        ContextualTdsFragment fragment =
+            (ContextualTdsFragment) ((SspiMessage) actual).encode(TestByteBufAllocator.TEST, 0);
+
+        assertThat(ByteBufUtil.getBytes(fragment.getByteBuf())).containsExactly(expectedPayload);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionConfigurationUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionConfigurationUnitTests.java
@@ -131,7 +131,38 @@ final class MssqlConnectionConfigurationUnitTests {
                 .hasFieldOrPropertyWithValue("password", "test-password")
                 .hasFieldOrPropertyWithValue("port", 1433)
                 .hasFieldOrPropertyWithValue("username", "test-username")
+                .hasFieldOrPropertyWithValue("integratedSecurity", false)
                 .hasFieldOrPropertyWithValue("sendStringParametersAsUnicode", true);
+    }
+
+    @Test
+    void integratedSecurityDoesNotRequireCredentials() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+                .host("sql.example.com")
+                .integratedSecurity()
+                .build();
+
+        assertThat(configuration)
+                .hasFieldOrPropertyWithValue("host", "sql.example.com")
+                .hasFieldOrPropertyWithValue("port", 1433)
+                .hasFieldOrPropertyWithValue("username", "")
+                .hasFieldOrPropertyWithValue("password", "")
+                .hasFieldOrPropertyWithValue("integratedSecurity", true);
+
+        assertThat(configuration.getServicePrincipalName()).isEqualTo("MSSQLSvc/sql.example.com:1433");
+    }
+
+    @Test
+    void integratedSecurityUsesConfiguredPortInServicePrincipalName() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+                .host("sql.example.com")
+                .port(1444)
+                .integratedSecurity()
+                .build();
+
+        assertThat(configuration.getServicePrincipalName()).isEqualTo("MSSQLSvc/sql.example.com:1444");
     }
 
     @Test
@@ -188,8 +219,27 @@ final class MssqlConnectionConfigurationUnitTests {
                 .hasFieldOrPropertyWithValue("password", "test-password")
                 .hasFieldOrPropertyWithValue("port", 1234)
                 .hasFieldOrPropertyWithValue("username", "test-username")
+                .hasFieldOrPropertyWithValue("integratedSecurity", false)
                 .hasFieldOrPropertyWithValue("sendStringParametersAsUnicode", true)
                 .hasFieldOrPropertyWithValue("hostNameInCertificate", "test-host");
+    }
+
+    @Test
+    void redirectPreservesIntegratedSecurityAndUpdatesServicePrincipalName() {
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+                .host("initial.example.com")
+                .integratedSecurity()
+                .build();
+
+        MssqlConnectionConfiguration target = configuration.withRedirect(Redirect.create("redirect.example.com", 1444));
+
+        assertThat(target)
+                .hasFieldOrPropertyWithValue("host", "redirect.example.com")
+                .hasFieldOrPropertyWithValue("port", 1444)
+                .hasFieldOrPropertyWithValue("integratedSecurity", true);
+
+        assertThat(target.getServicePrincipalName()).isEqualTo("MSSQLSvc/redirect.example.com:1444");
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryProviderTest.java
@@ -102,6 +102,40 @@ final class MssqlConnectionFactoryProviderTest {
     }
 
     @Test
+    void supportsIntegratedSecurityWithoutCredentials() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, MSSQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(INTEGRATED_SECURITY, true)
+            .build())).isTrue();
+    }
+
+    @Test
+    void doesNotSupportWithoutCredentialsWhenIntegratedSecurityIsDisabled() {
+        assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
+            .option(DRIVER, MSSQL_DRIVER)
+            .option(HOST, "test-host")
+            .option(INTEGRATED_SECURITY, false)
+            .build())).isFalse();
+    }
+
+    @Test
+    void shouldConfigureIntegratedSecurity() {
+
+        MssqlConnectionFactory factory = this.provider.create(ConnectionFactoryOptions.builder()
+            .option(DRIVER, MSSQL_DRIVER)
+            .option(HOST, "sql.example.com")
+            .option(PORT, 1444)
+            .option(INTEGRATED_SECURITY, true)
+            .build());
+
+        MssqlConnectionConfiguration configuration = factory.getConfiguration();
+
+        assertThat(configuration.isIntegratedSecurity()).isTrue();
+        assertThat(configuration.getServicePrincipalName()).isEqualTo("MSSQLSvc/sql.example.com:1444");
+    }
+
+    @Test
     void supportsAlternateDriverId() {
         assertThat(this.provider.supports(ConnectionFactoryOptions.builder()
             .option(DRIVER, ALTERNATE_MSSQL_DRIVER)

--- a/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/MssqlConnectionFactoryUnitTests.java
@@ -32,6 +32,7 @@ import reactor.util.annotation.Nullable;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -106,6 +107,70 @@ class MssqlConnectionFactoryUnitTests {
 
         assertThat(initial.isClosed()).isTrue();
         assertThat(redirect.isClosed()).isFalse();
+    }
+
+    @Test
+    void shouldUseIntegratedAuthenticationProvider() {
+
+        Prelogin preloginResponse = new Prelogin(Arrays.asList(
+            new Prelogin.Version(14, 0),
+            new Prelogin.Encryption(Prelogin.Encryption.ENCRYPT_NOT_SUP),
+            Prelogin.Terminator.INSTANCE));
+
+        ColumnMetadataToken columns = ColumnMetadataToken.create(COLUMNS);
+        RowToken rowToken = RowTokenFactory.create(columns, buffer -> {
+            Encode.uString(buffer, "Edition", ServerCharset.UNICODE.charset());
+            Encode.uString(buffer, "1.2.3", ServerCharset.CP1252.charset());
+        });
+
+        TestClient client = TestClient.builder()
+            .window()
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(Prelogin.class))
+            .thenRespond(preloginResponse)
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(Login7.class))
+            .thenRespond(DoneToken.create(0))
+            .done()
+            .assertNextRequestWith(actual -> assertThat(actual).isInstanceOf(SqlBatch.class))
+            .thenRespond(columns, rowToken, DoneToken.create(1))
+            .build();
+
+        MssqlConnectionConfiguration configuration = MssqlConnectionConfiguration.builder()
+            .host("sql.example.com")
+            .port(1444)
+            .integratedSecurity()
+            .build();
+
+        AtomicBoolean authenticationCreated = new AtomicBoolean();
+        AtomicBoolean authenticationClosed = new AtomicBoolean();
+
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(config -> Mono.just(client), config -> {
+
+            assertThat(config.getServicePrincipalName()).isEqualTo("MSSQLSvc/sql.example.com:1444");
+            authenticationCreated.set(true);
+
+            return new IntegratedAuthentication() {
+
+                @Override
+                public Mono<byte[]> initialToken() {
+                    return Mono.just(new byte[]{0x60, 0x01, 0x02});
+                }
+
+                @Override
+                public Mono<byte[]> nextToken(byte[] serverToken) {
+                    return Mono.error(new AssertionError("Unexpected SSPI challenge"));
+                }
+
+                @Override
+                public Mono<Void> close() {
+                    return Mono.fromRunnable(() -> authenticationClosed.set(true)).then();
+                }
+            };
+        }, configuration);
+
+        connectionFactory.create().as(StepVerifier::create).expectNextCount(1).verifyComplete();
+
+        assertThat(authenticationCreated).isTrue();
+        assertThat(authenticationClosed).isTrue();
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/WindowsIntegratedSecurityIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/WindowsIntegratedSecurityIntegrationTests.java
@@ -36,6 +36,8 @@ final class WindowsIntegratedSecurityIntegrationTests {
 
     private static final String DATABASE = "R2DBC_MSSQL_INTEGRATED_DATABASE";
 
+    private static final String EXPECTED_AUTH_SCHEME = "R2DBC_MSSQL_INTEGRATED_EXPECTED_AUTH_SCHEME";
+
     private static final String EXPECTED_USER = "R2DBC_MSSQL_INTEGRATED_EXPECTED_USER";
 
     private static final String HOST = "R2DBC_MSSQL_INTEGRATED_HOST";
@@ -77,19 +79,37 @@ final class WindowsIntegratedSecurityIntegrationTests {
         }
 
         String expectedUser = System.getenv(EXPECTED_USER);
+        String expectedAuthScheme = System.getenv(EXPECTED_AUTH_SCHEME);
 
         MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(builder.build());
 
         Flux.usingWhen(connectionFactory.create(),
-                connection -> Flux.from(connection.createStatement("SELECT SUSER_SNAME()").execute())
-                    .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, String.class))),
+                connection -> Flux.from(connection.createStatement(
+                        "SELECT SUSER_SNAME(), " +
+                            "CAST(CONNECTIONPROPERTY('auth_scheme') AS varchar(40))").execute())
+                    .flatMap(result -> result.map((row, rowMetadata) ->
+                        new AuthenticationDetails(
+                            row.get(0, String.class),
+                            row.get(1, String.class)))),
                 MssqlConnection::close)
             .as(StepVerifier::create)
-            .assertNext(actualUser -> {
-                assertThat(actualUser).isNotBlank();
+            .assertNext(authentication -> {
+
+                assertThat(authentication.user).isNotBlank();
+                assertThat(authentication.authScheme).isNotBlank();
+
+                assertThat(authentication.authScheme)
+                    .as("Windows Integrated Security authentication scheme")
+                    .isIn("KERBEROS", "NTLM");
 
                 if (hasText(expectedUser)) {
-                    assertThat(actualUser).isEqualToIgnoringCase(expectedUser);
+                    assertThat(authentication.user)
+                        .isEqualToIgnoringCase(expectedUser);
+                }
+
+                if (hasText(expectedAuthScheme)) {
+                    assertThat(authentication.authScheme)
+                        .isEqualToIgnoringCase(expectedAuthScheme);
                 }
             })
             .verifyComplete();
@@ -100,6 +120,20 @@ final class WindowsIntegratedSecurityIntegrationTests {
     }
 
     private static boolean isWindows() {
-        return System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH).contains("win");
+        return System.getProperty("os.name", "")
+            .toLowerCase(Locale.ENGLISH)
+            .contains("win");
+    }
+
+    private static final class AuthenticationDetails {
+
+        private final String user;
+
+        private final String authScheme;
+
+        private AuthenticationDetails(String user, String authScheme) {
+            this.user = user;
+            this.authScheme = authScheme;
+        }
     }
 }

--- a/src/test/java/io/r2dbc/mssql/WindowsIntegratedSecurityIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/WindowsIntegratedSecurityIntegrationTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Windows Integrated Security.
+ *
+ * <p>These tests require a Windows process with a valid Windows/domain identity and
+ * an external SQL Server that grants that identity access. The test is skipped unless
+ * {@code R2DBC_MSSQL_INTEGRATED_HOST} is configured.</p>
+ */
+final class WindowsIntegratedSecurityIntegrationTests {
+
+    private static final String DATABASE = "R2DBC_MSSQL_INTEGRATED_DATABASE";
+
+    private static final String EXPECTED_USER = "R2DBC_MSSQL_INTEGRATED_EXPECTED_USER";
+
+    private static final String HOST = "R2DBC_MSSQL_INTEGRATED_HOST";
+
+    private static final String PORT = "R2DBC_MSSQL_INTEGRATED_PORT";
+
+    private static final String SSL = "R2DBC_MSSQL_INTEGRATED_SSL";
+
+    private static final String TRUST_SERVER_CERTIFICATE = "R2DBC_MSSQL_INTEGRATED_TRUST_SERVER_CERTIFICATE";
+
+    @Test
+    void shouldConnectUsingCurrentWindowsIdentity() {
+
+        Assumptions.assumeTrue(isWindows(), "Windows Integrated Security requires Windows");
+
+        String host = System.getenv(HOST);
+        Assumptions.assumeTrue(hasText(host), HOST + " must be configured");
+
+        MssqlConnectionConfiguration.Builder builder = MssqlConnectionConfiguration.builder()
+            .host(host)
+            .integratedSecurity();
+
+        String port = System.getenv(PORT);
+        if (hasText(port)) {
+            builder.port(Integer.parseInt(port));
+        }
+
+        String database = System.getenv(DATABASE);
+        if (hasText(database)) {
+            builder.database(database);
+        }
+
+        if (Boolean.parseBoolean(System.getenv(SSL))) {
+            builder.enableSsl();
+        }
+
+        if (Boolean.parseBoolean(System.getenv(TRUST_SERVER_CERTIFICATE))) {
+            builder.trustServerCertificate();
+        }
+
+        String expectedUser = System.getenv(EXPECTED_USER);
+
+        MssqlConnectionFactory connectionFactory = new MssqlConnectionFactory(builder.build());
+
+        Flux.usingWhen(connectionFactory.create(),
+                connection -> Flux.from(connection.createStatement("SELECT SUSER_SNAME()").execute())
+                    .flatMap(result -> result.map((row, rowMetadata) -> row.get(0, String.class))),
+                MssqlConnection::close)
+            .as(StepVerifier::create)
+            .assertNext(actualUser -> {
+                assertThat(actualUser).isNotBlank();
+
+                if (hasText(expectedUser)) {
+                    assertThat(actualUser).isEqualToIgnoringCase(expectedUser);
+                }
+            })
+            .verifyComplete();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH).contains("win");
+    }
+}

--- a/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
@@ -78,6 +78,32 @@ final class WindowsSspiAuthenticationUnitTests {
     }
 
     @Test
+    void shouldCompleteWithoutFinalClientToken() {
+
+        byte[] initialToken = new byte[]{0x60, 0x01, 0x02};
+        byte[] finalServerToken = new byte[]{0x31, 0x32};
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.addResult(W32Errors.SEC_I_CONTINUE_NEEDED, initialToken);
+        sspi.addResult(W32Errors.SEC_E_OK, new byte[0]);
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectNextMatches(actual -> Arrays.equals(actual, initialToken))
+            .verifyComplete();
+
+        StepVerifier.create(authentication.nextToken(finalServerToken))
+            .verifyComplete();
+
+        assertThat(sspi.inputs).hasSize(2);
+        assertThat(sspi.inputs.get(1)).containsExactly(finalServerToken);
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+    }
+
+    @Test
     void shouldCompleteSspiTokenWhenRequested() {
 
         TestSspiSupport sspi = new TestSspiSupport();

--- a/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
@@ -78,6 +78,54 @@ final class WindowsSspiAuthenticationUnitTests {
     }
 
     @Test
+    void shouldUseSecurityPackageMaximumTokenSize() {
+
+        byte[] initialToken = new byte[]{0x60, 0x01};
+        byte[] challenge = new byte[]{0x11};
+        byte[] response = new byte[]{0x21, 0x22};
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.maxTokenSize = 32768;
+        sspi.addResult(W32Errors.SEC_I_CONTINUE_NEEDED, initialToken);
+        sspi.addResult(W32Errors.SEC_E_OK, response);
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectNextMatches(actual -> Arrays.equals(actual, initialToken))
+            .verifyComplete();
+
+        StepVerifier.create(authentication.nextToken(challenge))
+            .expectNextMatches(actual -> Arrays.equals(actual, response))
+            .verifyComplete();
+
+        assertThat(sspi.queryMaxTokenSizeCount).isEqualTo(1);
+        assertThat(sspi.outputBufferSizes).containsExactly(32768, 32768);
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+    }
+
+    @Test
+    void shouldRejectInvalidSecurityPackageMaximumTokenSize() {
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.maxTokenSize = 0;
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectErrorMatches(error -> error instanceof IllegalStateException &&
+                error.getMessage().contains("positive maximum token size"))
+            .verify();
+
+        assertThat(sspi.queryMaxTokenSizeCount).isEqualTo(1);
+        assertThat(sspi.acquireCount).isZero();
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+    }
+    @Test
     void shouldCompleteWithoutFinalClientToken() {
 
         byte[] initialToken = new byte[]{0x60, 0x01, 0x02};
@@ -171,6 +219,12 @@ final class WindowsSspiAuthenticationUnitTests {
 
         private final List<String> targetNames = new ArrayList<>();
 
+        private final List<Integer> outputBufferSizes = new ArrayList<>();
+
+        private int maxTokenSize = 48000;
+
+        private int queryMaxTokenSizeCount;
+
         private int acquireStatus = W32Errors.SEC_E_OK;
 
         private int acquireCount;
@@ -187,6 +241,11 @@ final class WindowsSspiAuthenticationUnitTests {
             this.results.add(new Result(status, token));
         }
 
+        @Override
+        public int queryMaxTokenSize() {
+            this.queryMaxTokenSizeCount++;
+            return this.maxTokenSize;
+        }
         @Override
         public int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry) {
 
@@ -207,6 +266,7 @@ final class WindowsSspiAuthenticationUnitTests {
 
             this.targetNames.add(targetName);
             this.inputs.add(input == null ? null : input.getBuffer(0).getBytes());
+            this.outputBufferSizes.add(output.getBuffer(0).cbBuffer);
 
             Result result = this.results.get(this.resultIndex++);
 

--- a/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/WindowsSspiAuthenticationUnitTests.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Sspi;
+import com.sun.jna.platform.win32.Sspi.CredHandle;
+import com.sun.jna.platform.win32.Sspi.CtxtHandle;
+import com.sun.jna.platform.win32.Sspi.TimeStamp;
+import com.sun.jna.platform.win32.SspiUtil.ManagedSecBufferDesc;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.ptr.IntByReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link WindowsSspiAuthentication}.
+ *
+ * @author Daniel Pachali
+ */
+final class WindowsSspiAuthenticationUnitTests {
+
+    @Test
+    void shouldProduceInitialAndContinuationTokensAndReleaseResources() {
+
+        byte[] initialToken = new byte[]{0x60, 0x01, 0x02};
+        byte[] challenge = new byte[]{0x11, 0x12};
+        byte[] response = new byte[]{0x21, 0x22, 0x23};
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.addResult(W32Errors.SEC_I_CONTINUE_NEEDED, initialToken);
+        sspi.addResult(W32Errors.SEC_E_OK, response);
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectNextMatches(actual -> Arrays.equals(actual, initialToken))
+            .verifyComplete();
+
+        StepVerifier.create(authentication.nextToken(challenge))
+            .expectNextMatches(actual -> Arrays.equals(actual, response))
+            .verifyComplete();
+
+        assertThat(sspi.acquireCount).isEqualTo(1);
+        assertThat(sspi.inputs).hasSize(2);
+        assertThat(sspi.inputs.get(0)).isNull();
+        assertThat(sspi.inputs.get(1)).containsExactly(challenge);
+        assertThat(sspi.targetNames).containsOnly("MSSQLSvc/sql.example.com:1433");
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+        StepVerifier.create(authentication.close()).verifyComplete();
+
+        assertThat(sspi.deleteCount).isEqualTo(1);
+        assertThat(sspi.freeCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCompleteSspiTokenWhenRequested() {
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.addResult(0x00090314, new byte[]{0x60, 0x01});
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectNextMatches(actual -> Arrays.equals(actual, new byte[]{0x60, 0x01}))
+            .verifyComplete();
+
+        assertThat(sspi.completeCount).isEqualTo(1);
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+    }
+
+    @Test
+    void shouldPropagateAcquireCredentialsFailure() {
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.acquireStatus = 0x8009030E;
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectErrorMatches(error -> error instanceof IllegalStateException &&
+                error.getMessage().contains("AcquireCredentialsHandle") &&
+                error.getMessage().contains("0x8009030E"))
+            .verify();
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+
+        assertThat(sspi.freeCount).isZero();
+        assertThat(sspi.deleteCount).isZero();
+    }
+
+    @Test
+    void shouldFreeCredentialsAfterContextInitializationFailure() {
+
+        TestSspiSupport sspi = new TestSspiSupport();
+        sspi.addResult(0x80090302, new byte[0]);
+
+        WindowsSspiAuthentication authentication = new WindowsSspiAuthentication(
+            "MSSQLSvc/sql.example.com:1433", sspi, Schedulers.immediate());
+
+        StepVerifier.create(authentication.initialToken())
+            .expectErrorMatches(error -> error instanceof IllegalStateException &&
+                error.getMessage().contains("InitializeSecurityContext") &&
+                error.getMessage().contains("0x80090302"))
+            .verify();
+
+        StepVerifier.create(authentication.close()).verifyComplete();
+
+        assertThat(sspi.freeCount).isEqualTo(1);
+        assertThat(sspi.deleteCount).isZero();
+    }
+
+    private static final class TestSspiSupport implements WindowsSspiAuthentication.SspiSupport {
+
+        private final List<Result> results = new ArrayList<>();
+
+        private final List<byte[]> inputs = new ArrayList<>();
+
+        private final List<String> targetNames = new ArrayList<>();
+
+        private int acquireStatus = W32Errors.SEC_E_OK;
+
+        private int acquireCount;
+
+        private int completeCount;
+
+        private int deleteCount;
+
+        private int freeCount;
+
+        private int resultIndex;
+
+        void addResult(int status, byte[] token) {
+            this.results.add(new Result(status, token));
+        }
+
+        @Override
+        public int acquireCredentialsHandle(CredHandle credentials, TimeStamp expiry) {
+
+            this.acquireCount++;
+
+            if (this.acquireStatus == W32Errors.SEC_E_OK) {
+                credentials.dwLower = Pointer.createConstant(1);
+                credentials.dwUpper = Pointer.createConstant(2);
+            }
+
+            return this.acquireStatus;
+        }
+
+        @Override
+        public int initializeSecurityContext(CredHandle credentials, @Nullable CtxtHandle context, String targetName,
+                                             @Nullable ManagedSecBufferDesc input, CtxtHandle newContext,
+                                             ManagedSecBufferDesc output, IntByReference contextAttributes) {
+
+            this.targetNames.add(targetName);
+            this.inputs.add(input == null ? null : input.getBuffer(0).getBytes());
+
+            Result result = this.results.get(this.resultIndex++);
+
+            if (result.status == W32Errors.SEC_E_OK ||
+                result.status == W32Errors.SEC_I_CONTINUE_NEEDED ||
+                result.status == 0x00090313 ||
+                result.status == 0x00090314) {
+                newContext.dwLower = Pointer.createConstant(3);
+                newContext.dwUpper = Pointer.createConstant(4);
+            }
+
+            if (result.token.length > 0) {
+                output.getBuffer(0).pvBuffer.write(0, result.token, 0, result.token.length);
+            }
+            output.getBuffer(0).cbBuffer = result.token.length;
+
+            return result.status;
+        }
+
+        @Override
+        public int completeAuthToken(CtxtHandle context, ManagedSecBufferDesc token) {
+            this.completeCount++;
+            return W32Errors.SEC_E_OK;
+        }
+
+        @Override
+        public int deleteSecurityContext(CtxtHandle context) {
+            this.deleteCount++;
+            return W32Errors.SEC_E_OK;
+        }
+
+        @Override
+        public int freeCredentialsHandle(CredHandle credentials) {
+            this.freeCount++;
+            return W32Errors.SEC_E_OK;
+        }
+
+    }
+
+    private static final class Result {
+
+        private final int status;
+
+        private final byte[] token;
+
+        private Result(int status, byte[] token) {
+            this.status = status;
+            this.token = token;
+        }
+
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/message/token/Login7UnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/Login7UnitTests.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 final class Login7UnitTests {
 
     @Test
-    void shouldRenderSimpleLoginPacket() {
+    void shouldKeepSqlAuthenticationLoginPacketUnchanged() {
 
         Login7 login7 = Login7.builder()
             .serverName("localhost")
@@ -64,6 +64,71 @@ final class Login7UnitTests {
 
         assertThat(ByteBufUtil.prettyHexDump(buffer))
             .isEqualTo(ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(expected)));
+    }
+
+
+    @Test
+    void shouldEncodeIntegratedSecurityLoginPacket() {
+
+        byte[] initialSspiToken = new byte[]{(byte) 0x60, (byte) 0x82, 0x01, 0x23};
+
+        Login7 login7 = Login7.builder()
+            .serverName("localhost")
+            .hostName("some-fancy-hostname")
+            .database("master")
+            .clientLibraryName("MyDriver")
+            .applicationName("MyApp")
+            .clientLibraryVersion(Version.parse("6.4"))
+            .tdsVersion(TDSVersion.VER_DENALI)
+            .integratedSecurity(initialSspiToken)
+            .build();
+
+        ByteBuf buffer = Unpooled.buffer(400);
+        login7.encode(buffer);
+
+        assertThat(buffer.getIntLE(0)).isEqualTo(buffer.readableBytes());
+
+        // OptionFlags2.fIntSecurity
+        assertThat(buffer.getUnsignedByte(25) & 0x80).isEqualTo(0x80);
+
+        // Username and password are omitted from integrated-security LOGIN7.
+        assertThat(buffer.getUnsignedShortLE(42)).isZero();
+        assertThat(buffer.getUnsignedShortLE(46)).isZero();
+
+        int sspiOffset = buffer.getUnsignedShortLE(78);
+        int sspiLength = buffer.getUnsignedShortLE(80);
+
+        assertThat(sspiOffset).isGreaterThanOrEqualTo(94);
+        assertThat(sspiLength).isEqualTo(initialSspiToken.length);
+        assertThat(ByteBufUtil.getBytes(buffer, sspiOffset, sspiLength)).containsExactly(initialSspiToken);
+
+        // cbSSPILong is not used for a short SSPI token.
+        assertThat(buffer.getIntLE(90)).isZero();
+    }
+
+    @Test
+    void shouldEncodeLongSspiLength() {
+
+        byte[] initialSspiToken = new byte[0x10000];
+        initialSspiToken[0] = 0x60;
+        initialSspiToken[initialSspiToken.length - 1] = 0x01;
+
+        Login7 login7 = Login7.builder()
+            .serverName("localhost")
+            .hostName("some-fancy-hostname")
+            .database("master")
+            .clientLibraryName("MyDriver")
+            .applicationName("MyApp")
+            .clientLibraryVersion(Version.parse("6.4"))
+            .tdsVersion(TDSVersion.VER_DENALI)
+            .integratedSecurity(initialSspiToken)
+            .build();
+
+        ByteBuf buffer = Unpooled.buffer(0x11000);
+        login7.encode(buffer);
+
+        assertThat(buffer.getUnsignedShortLE(80)).isEqualTo(0xFFFF);
+        assertThat(buffer.getIntLE(90)).isEqualTo(initialSspiToken.length);
     }
 
     @Test

--- a/src/test/java/io/r2dbc/mssql/message/token/SspiMessageUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/SspiMessageUnitTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.message.token;
+
+import io.netty.buffer.ByteBufUtil;
+import io.r2dbc.mssql.message.header.Type;
+import io.r2dbc.mssql.message.tds.ContextualTdsFragment;
+import io.r2dbc.mssql.util.TestByteBufAllocator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SspiMessage}.
+ *
+ * @author Daniel Pachali
+ */
+final class SspiMessageUnitTests {
+
+    @Test
+    void shouldEncodeSspiPacket() {
+
+        byte[] sspiBuffer = new byte[]{0x01, 0x02, 0x03, 0x04};
+
+        SspiMessage message = SspiMessage.create(sspiBuffer);
+        ContextualTdsFragment fragment =
+            (ContextualTdsFragment) message.encode(TestByteBufAllocator.TEST, 0);
+
+        assertThat(fragment.getHeaderOptions().getType()).isEqualTo(Type.SSPI);
+        assertThat(fragment.getHeaderOptions().getStatus().getValue()).isEqualTo((byte) 0);
+        assertThat(ByteBufUtil.getBytes(fragment.getByteBuf())).containsExactly(sspiBuffer);
+    }
+
+    @Test
+    void shouldEncodeRawSspiPayloadWithoutTokenHeader() {
+
+        byte[] sspiBuffer = new byte[]{(byte) 0x60, (byte) 0x82, 0x01, 0x23};
+
+        SspiMessage message = SspiMessage.create(sspiBuffer);
+        ContextualTdsFragment fragment =
+            (ContextualTdsFragment) message.encode(TestByteBufAllocator.TEST, 0);
+
+        assertThat(ByteBufUtil.getBytes(fragment.getByteBuf()))
+            .containsExactly((byte) 0x60, (byte) 0x82, (byte) 0x01, (byte) 0x23);
+    }
+
+    @Test
+    void shouldExposeSymbolicName() {
+
+        SspiMessage message = SspiMessage.create(new byte[]{0x01});
+
+        assertThat(message.getName()).isEqualTo("SSPI");
+        assertThat(message.toString()).contains("length=1");
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/message/token/SspiTokenUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/SspiTokenUnitTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql.message.token;
+
+import io.netty.buffer.ByteBuf;
+import io.r2dbc.mssql.util.HexUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SspiToken}.
+ *
+ * @author Daniel Pachali
+ */
+final class SspiTokenUnitTests {
+
+    @Test
+    void shouldDecodeSspiToken() {
+
+        ByteBuf buffer = HexUtils.decodeToByteBuf("ED040001020304");
+
+        assertThat(buffer.readByte()).isEqualTo(SspiToken.TYPE);
+
+        SspiToken token = SspiToken.decode(buffer);
+
+        assertThat(token.getType()).isEqualTo(SspiToken.TYPE);
+        assertThat(token.getName()).isEqualTo("SSPI");
+        assertThat(token.getSspiBuffer()).containsExactly(new byte[]{0x01, 0x02, 0x03, 0x04});
+        assertThat(buffer.isReadable()).isFalse();
+    }
+
+    @Test
+    void canDecodeShouldReportDecodability() {
+
+        CanDecodeTestSupport.testCanDecode(HexUtils.decodeToByteBuf("040001020304"), SspiToken::canDecode);
+    }
+
+    @Test
+    void shouldDecodeEmptySspiBuffer() {
+
+        ByteBuf buffer = HexUtils.decodeToByteBuf("0000");
+
+        SspiToken token = SspiToken.decode(buffer);
+
+        assertThat(token.getSspiBuffer()).isEmpty();
+        assertThat(buffer.isReadable()).isFalse();
+    }
+
+    @Test
+    void shouldLeaveFollowingTokenDataUnread() {
+
+        ByteBuf buffer = HexUtils.decodeToByteBuf("0300010203AA");
+
+        SspiToken token = SspiToken.decode(buffer);
+
+        assertThat(token.getSspiBuffer()).containsExactly(new byte[]{0x01, 0x02, 0x03});
+        assertThat(buffer.readableBytes()).isEqualTo(1);
+        assertThat(buffer.readByte()).isEqualTo((byte) 0xAA);
+    }
+
+    @Test
+    void shouldDecodeSspiTokenThroughTabular() {
+
+        ByteBuf buffer = HexUtils.decodeToByteBuf("ED040001020304");
+
+        Tabular tabular = Tabular.decode(buffer, false);
+
+        assertThat(tabular.getTokens()).hasSize(1);
+        assertThat(tabular.getTokens().get(0)).isInstanceOf(SspiToken.class);
+
+        SspiToken token = (SspiToken) tabular.getTokens().get(0);
+
+        assertThat(token.getSspiBuffer()).containsExactly(new byte[]{0x01, 0x02, 0x03, 0x04});
+    }
+
+}


### PR DESCRIPTION
## Summary

Add Windows Integrated Security support using the credentials of the
current Windows process.

The implementation uses Windows SSPI with the `Negotiate` security
package, allowing Windows to select Kerberos or NTLM according to the
environment and security policy.

SQL Server username/password authentication remains unchanged.

## Implementation

- Add TDS SSPI challenge token decoding (`0xED`)
- Add TDS SSPI client messages (`0x11`)
- Add Integrated Security support to LOGIN7
- Add reactive multi-round SSPI negotiation to the login flow
- Add a Windows SSPI provider using JNA
- Use the current Windows process credentials
- Build the SQL Server SPN as `MSSQLSvc/<host>:<port>`
- Recompute the SPN when following a SQL Server redirect
- Query the Negotiate package's `cbMaxToken` instead of using a fixed
  SSPI token buffer size
- Support SSPI buffers larger than 65535 bytes through `cbSSPILong`
- Add `integratedSecurity` connection configuration
- Keep JNA as an optional dependency
- Add documentation and an opt-in Windows integration test
- Verify the negotiated Windows authentication scheme in the integration test

## Configuration

URL:

```text
r2dbc:mssql://sql.example.com:1433/database?integratedSecurity=true
```

Programmatic configuration:

```java
MssqlConnectionConfiguration configuration =
    MssqlConnectionConfiguration.builder()
        .host("sql.example.com")
        .port(1433)
        .database("database")
        .integratedSecurity()
        .build();
```

When Integrated Security is enabled, `username` and `password` are not
required.

Applications using this authentication mode must include
`jna-platform`.

## Scope

This PR intentionally focuses on Windows trusted authentication using
the credentials of the process running the JVM.

Out of scope for this change:

- Azure AD / Microsoft Entra ID / MSAL authentication
- Managed Identity
- ActiveDirectoryPassword
- Explicit username/password NTLM credentials
- Linux Kerberos authentication

## Validation

The implementation was validated against real Windows SQL Server
environments using Windows-only authentication.

The integration test:

- establishes a TCP connection using Windows Integrated Security
- completes the SSPI Negotiate challenge/response exchange
- executes a SQL query successfully
- verifies that `SUSER_SNAME()` matches the expected Windows identity
- verifies the negotiated authentication scheme using
  `CONNECTIONPROPERTY('auth_scheme')`
- can optionally require a specific scheme through
  `R2DBC_MSSQL_INTEGRATED_EXPECTED_AUTH_SCHEME`

Both authentication paths selected by Windows `Negotiate` have been
validated end-to-end:

- NTLM against a real Windows SQL Server instance
- Kerberos against an Active Directory domain SQL Server with a registered
  `MSSQLSvc/<host>:<port>` SPN

For the Kerberos validation, the Kerberos ticket cache was cleared before
running the integration test. The R2DBC connection caused Windows SSPI to
obtain the SQL Server service ticket, and SQL Server reported
`CONNECTIONPROPERTY('auth_scheme') = KERBEROS` from the same connection.

Additional validation:

- `WindowsSspiAuthenticationUnitTests`: 7 tests, all passing
- Windows Integrated Security E2E: NTLM and Kerberos both validated
- Existing SQL authentication tests with JNA excluded from the test
  runtime: 32 tests, all passing
- `mvn clean verify`: BUILD SUCCESS
- 917 unit/regression tests passing
- 167 integration tests passing

Addresses #101
