### PR TITLE
Advance past PLP columns when checking row decodability

### DIFF
--- a/src/main/java/io/r2dbc/mssql/message/tds/PlpBuffer.java
+++ b/src/main/java/io/r2dbc/mssql/message/tds/PlpBuffer.java
@@ -123,24 +123,36 @@ public final class PlpBuffer {
     public ByteBuf readRetainedStream() {
 
         int startIndex = this.buffer.readerIndex();
-        PlpLength totalLength = decodeLength();
-
-        if (!totalLength.isNull()) {
-            while (true) {
-
-                Length chunkLength = Length.decode(this.buffer, this.type);
-
-                if (chunkLength.isEmpty()) {
-                    break;
-                }
-
-                chunkLength.map(this.buffer::skipBytes);
-            }
-        }
+        skipStream();
 
         int endIndex = this.buffer.readerIndex();
         this.buffer.readerIndex(startIndex);
         return this.buffer.readRetainedSlice(endIndex - startIndex);
+    }
+
+    /**
+     * Skip the complete framed PLP stream (PLP length header, chunk length headers, chunk data, and terminator), advancing the buffer past the stream.
+     * Use this method to skip over a PLP value within a token stream, e.g. when checking decodability of subsequent values.
+     * <p>The buffer must be positioned at the PLP length header and contain the complete stream, see {@link #canDecode()}.
+     */
+    public void skipStream() {
+
+        PlpLength totalLength = decodeLength();
+
+        if (totalLength.isNull()) {
+            return;
+        }
+
+        while (true) {
+
+            Length chunkLength = Length.decode(this.buffer, this.type);
+
+            if (chunkLength.isEmpty()) {
+                return;
+            }
+
+            chunkLength.map(this.buffer::skipBytes);
+        }
     }
 
     /**

--- a/src/main/java/io/r2dbc/mssql/message/token/RowToken.java
+++ b/src/main/java/io/r2dbc/mssql/message/token/RowToken.java
@@ -134,15 +134,24 @@ public class RowToken extends AbstractReferenceCounted implements DataToken {
     }
 
     /**
-     * Returns whether a PLP stream can be decoded where can be decoded means that we have received at least the PLP length header.
+     * Returns whether a PLP stream can be decoded, i.e. whether the buffer contains the complete PLP stream including the terminator. Advances the buffer past the PLP stream
+     * if it can be decoded so that subsequent columns are checked from their correct position.
      *
      * @param buffer data buffer.
      * @param column the related column.
-     * @return {@code true} if the PLP sream can be decoded.
+     * @return {@code true} if the PLP stream can be decoded.
      * @see LengthStrategy#PARTLENTYPE
      */
     private static boolean canDecodePlp(ByteBuf buffer, Column column) {
-        return PlpBuffer.of(buffer, column.getType()).canDecode();
+
+        PlpBuffer plpBuffer = PlpBuffer.of(buffer, column.getType());
+
+        if (!plpBuffer.canDecode()) {
+            return false;
+        }
+
+        plpBuffer.skipStream();
+        return true;
     }
 
     private static RowToken doDecode(ByteBuf buffer, Column[] columns) {

--- a/src/test/java/io/r2dbc/mssql/PlpColumnIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/PlpColumnIntegrationTests.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +41,7 @@ class PlpColumnIntegrationTests extends IntegrationTestSupport {
         connection.createStatement("DROP TABLE plp_test").execute()
             .flatMap(MssqlResult::getRowsUpdated)
             .onErrorResume(e -> Mono.empty())
-            .thenMany(connection.createStatement("CREATE TABLE plp_test (first NVARCHAR(MAX) NULL, second NVARCHAR(MAX) NULL, id INT NULL)")
+            .thenMany(connection.createStatement("CREATE TABLE plp_test (first NVARCHAR(MAX) NULL, second NVARCHAR(MAX) NULL, id INT NULL, created DATETIME2 NULL)")
                 .execute().flatMap(MssqlResult::getRowsUpdated))
             .as(StepVerifier::create)
             .verifyComplete();
@@ -49,7 +50,7 @@ class PlpColumnIntegrationTests extends IntegrationTestSupport {
     @Test
     void shouldReadMultiplePlpColumnsSpanningPackets() {
 
-        connection.createStatement("INSERT INTO plp_test SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), REPLICATE(N'b', 1500), 1 FROM sys.all_objects")
+        connection.createStatement("INSERT INTO plp_test (first, second, id) SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), REPLICATE(N'b', 1500), 1 FROM sys.all_objects")
             .execute()
             .flatMap(MssqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -70,7 +71,7 @@ class PlpColumnIntegrationTests extends IntegrationTestSupport {
     @Test
     void shouldReadPlpFollowedByIntSpanningPackets() {
 
-        connection.createStatement("INSERT INTO plp_test SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), NULL, 42 FROM sys.all_objects")
+        connection.createStatement("INSERT INTO plp_test (first, second, id) SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), NULL, 42 FROM sys.all_objects")
             .execute()
             .flatMap(MssqlResult::getRowsUpdated)
             .as(StepVerifier::create)
@@ -88,4 +89,24 @@ class PlpColumnIntegrationTests extends IntegrationTestSupport {
             .verify(Duration.ofSeconds(30));
     }
 
+
+    @Test
+    void shouldReadPlpNullFollowedByDatetimeUsingCursor() {
+
+        connection.createStatement("INSERT INTO plp_test (first, id, created) VALUES (NULL, 42, '2026-09-12T10:15:30')")
+            .execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext(1L)
+            .verifyComplete();
+
+        connection.createStatement("SELECT first, created FROM plp_test WHERE id = @P0 /* cursored */")
+            .bind("P0", 42)
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get("created", LocalDateTime.class)))
+            .as(StepVerifier::create)
+            .expectNext(LocalDateTime.parse("2026-09-12T10:15:30"))
+            .expectComplete()
+            .verify(Duration.ofSeconds(30));
+    }
 }

--- a/src/test/java/io/r2dbc/mssql/PlpColumnIntegrationTests.java
+++ b/src/test/java/io/r2dbc/mssql/PlpColumnIntegrationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.mssql;
+
+import io.r2dbc.mssql.util.IntegrationTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for rows containing PLP ({@code MAX}) columns followed by further columns.
+ */
+class PlpColumnIntegrationTests extends IntegrationTestSupport {
+
+    static final int ROWS = 500;
+
+    @BeforeEach
+    void setUp() {
+
+        connection.createStatement("DROP TABLE plp_test").execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .onErrorResume(e -> Mono.empty())
+            .thenMany(connection.createStatement("CREATE TABLE plp_test (first NVARCHAR(MAX) NULL, second NVARCHAR(MAX) NULL, id INT NULL)")
+                .execute().flatMap(MssqlResult::getRowsUpdated))
+            .as(StepVerifier::create)
+            .verifyComplete();
+    }
+
+    @Test
+    void shouldReadMultiplePlpColumnsSpanningPackets() {
+
+        connection.createStatement("INSERT INTO plp_test SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), REPLICATE(N'b', 1500), 1 FROM sys.all_objects")
+            .execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext((long) ROWS)
+            .verifyComplete();
+
+        connection.createStatement("SELECT first, second, id FROM plp_test")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get("first", String.class).length() + row.get("second", String.class).length()))
+            .as(StepVerifier::create)
+            .recordWith(ArrayList::new)
+            .expectNextCount(ROWS)
+            .consumeRecordedWith(lengths -> assertThat(lengths).containsOnly(2500))
+            .expectComplete()
+            .verify(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldReadPlpFollowedByIntSpanningPackets() {
+
+        connection.createStatement("INSERT INTO plp_test SELECT TOP " + ROWS + " REPLICATE(N'a', 1000), NULL, 42 FROM sys.all_objects")
+            .execute()
+            .flatMap(MssqlResult::getRowsUpdated)
+            .as(StepVerifier::create)
+            .expectNext((long) ROWS)
+            .verifyComplete();
+
+        connection.createStatement("SELECT first, id FROM plp_test")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get("first", String.class).length() + row.get("id", Integer.class)))
+            .as(StepVerifier::create)
+            .recordWith(ArrayList::new)
+            .expectNextCount(ROWS)
+            .consumeRecordedWith(values -> assertThat(values).containsOnly(1042))
+            .expectComplete()
+            .verify(Duration.ofSeconds(30));
+    }
+
+}

--- a/src/test/java/io/r2dbc/mssql/message/token/NbcRowTokenUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/NbcRowTokenUnitTests.java
@@ -91,4 +91,18 @@ class NbcRowTokenUnitTests {
         assertThat(row.getColumnData(0).readableBytes()).isEqualTo(5);
         assertThat(row.getColumnData(1)).isNull();
     }
+
+    @Test
+    void canDecodeShouldReportDecodabilityOfPlpFollowedByPlp() {
+
+        TypeInformation integerType = TypeInformation.builder().withServerType(SqlServerType.INTEGER).withLengthStrategy(LengthStrategy.BYTELENTYPE).build();
+        TypeInformation plpType = TypeInformation.builder().withServerType(SqlServerType.VARCHARMAX).withLengthStrategy(LengthStrategy.PARTLENTYPE).withCharset(ServerCharset.CP1252.charset()).build();
+        Column[] columns = {new Column(0, "first", plpType), new Column(1, "id", integerType), new Column(2, "second", plpType)};
+
+        // null bitmap: column 1 is null
+        ByteBuf rowData = HexUtils.decodeToByteBuf("02 0400000000000000 04000000 61626364 00000000 0400000000000000 04000000 65666768 00000000");
+
+        CanDecodeTestSupport.testCanDecode(rowData, buffer -> NbcRowToken.canDecode(buffer, columns));
+        rowData.release();
+    }
 }

--- a/src/test/java/io/r2dbc/mssql/message/token/RowTokenUnitTests.java
+++ b/src/test/java/io/r2dbc/mssql/message/token/RowTokenUnitTests.java
@@ -176,6 +176,51 @@ class RowTokenUnitTests {
         assertThat(contentData.refCnt()).isZero();
     }
 
+    @Test
+    void canDecodeShouldReportDecodabilityOfPlpFollowedByPlp() {
+
+        TypeInformation plpType = TypeInformation.builder().withServerType(SqlServerType.VARCHARMAX).withLengthStrategy(LengthStrategy.PARTLENTYPE).withCharset(ServerCharset.CP1252.charset()).build();
+        Column[] columns = {new Column(0, "first", plpType), new Column(1, "second", plpType)};
+
+        ByteBuf rowData = HexUtils.decodeToByteBuf("0400000000000000 04000000 61626364 00000000 0400000000000000 04000000 65666768 00000000");
+
+        CanDecodeTestSupport.testCanDecode(rowData, buffer -> RowToken.canDecode(buffer, columns));
+        rowData.release();
+    }
+
+    @Test
+    void canDecodeShouldReportDecodabilityOfPlpFollowedByInt() {
+
+        TypeInformation integerType = TypeInformation.builder().withServerType(SqlServerType.INTEGER).withLengthStrategy(LengthStrategy.BYTELENTYPE).build();
+        TypeInformation plpType = TypeInformation.builder().withServerType(SqlServerType.VARCHARMAX).withLengthStrategy(LengthStrategy.PARTLENTYPE).withCharset(ServerCharset.CP1252.charset()).build();
+        Column[] columns = {new Column(0, "content", plpType), new Column(1, "id", integerType)};
+
+        ByteBuf rowData = HexUtils.decodeToByteBuf("0400000000000000 04000000 61626364 00000000 04 01000000");
+
+        CanDecodeTestSupport.testCanDecode(rowData, buffer -> RowToken.canDecode(buffer, columns));
+        rowData.release();
+    }
+
+    @Test
+    void canDecodeShouldReportDecodabilityOfPlpNullFollowedByInt() {
+
+        TypeInformation integerType = TypeInformation.builder().withServerType(SqlServerType.INTEGER).withLengthStrategy(LengthStrategy.BYTELENTYPE).build();
+        TypeInformation plpType = TypeInformation.builder().withServerType(SqlServerType.VARCHARMAX).withLengthStrategy(LengthStrategy.PARTLENTYPE).withCharset(ServerCharset.CP1252.charset()).build();
+        Column[] columns = {new Column(0, "content", plpType), new Column(1, "id", integerType)};
+
+        String rowData = "FFFFFFFFFFFFFFFF 04 01000000";
+
+        CanDecodeTestSupport.testCanDecode(HexUtils.decodeToByteBuf(rowData), buffer -> RowToken.canDecode(buffer, columns));
+
+        ByteBuf buffer = HexUtils.decodeToByteBuf(rowData);
+        RowToken row = RowToken.decode(buffer, columns);
+        assertThat(row.getColumnData(0)).isNull();
+        assertThat(row.getColumnData(1).readableBytes()).isEqualTo(5);
+
+        buffer.release();
+        row.release();
+    }
+
     private static ByteBuf loadRowData(String resource) throws IOException {
 
         StringBuffer buffer = new StringBuffer();


### PR DESCRIPTION
Fixes #350.

`PlpBuffer.canDecode()` (introduced in 72a8004 / 4d61f6a, "Revise PLP handling in codecs and improve length management") resets the reader index after checking a PLP stream. `RowToken.canDecode()` and `NbcRowToken.canDecode()` rely on each column check advancing the buffer, so every column after a `MAX` column is checked from the wrong offset:

- incomplete rows are reported as decodable → `IndexOutOfBoundsException` in `PlpBuffer.readRetainedStream()` / `RowToken.decode()` (the #350 stack trace), connection is terminated;
- complete rows can be reported as not decodable → the query hangs. This happens with cursored execution (the default for `SELECT`), where a NULL PLP value is sent inline in a `ROW` token: e.g. a NULL `NVARCHAR(MAX)` followed by a `DATETIME2`/`UNIQUEIDENTIFIER`/`DECIMAL`/`BIT` column reads the PLP NULL marker as that column's length and waits for bytes that never arrive. This is the hang reported in #351.

1.0.5 advanced past the PLP stream in `canDecodePlp`. This restores that: `RowToken.canDecodePlp` skips the stream after a successful `canDecode()`. `PlpBuffer.skipStream()` is extracted from `readRetainedStream()`.

Existing tests only had the PLP column last, which is why this wasn't caught.

Tests:
- `RowTokenUnitTests` / `NbcRowTokenUnitTests`: PLP followed by PLP, PLP followed by INT, PLP NULL followed by INT (truncation via `CanDecodeTestSupport`). All fail without the fix.
- `PlpColumnIntegrationTests` (SQL Server 2022):
  - 500 rows with two `NVARCHAR(MAX)` columns, and `NVARCHAR(MAX)` followed by `INT`, spanning multiple packets: fail on 1.0.6 with the #350 exception, pass with the fix.
  - NULL `NVARCHAR(MAX)` followed by `DATETIME2` using a cursor: hangs on 1.0.6 (times out after 30s), passes with the fix.
- `./mvnw verify` (unit + integration tests) green locally against SQL Server 2022.

I also ran a matrix of PLP columns (`NVARCHAR(MAX)` small/large/NULL, `VARBINARY(MAX)`, geometry, `FOR JSON`) × 7 trailing column types × batch/RPC/cursored × 1/200 rows against 1.0.5, 1.0.6 and this branch: 1.0.6 has 8 hangs and 7 `IndexOutOfBoundsException`s, 1.0.5 and this branch have none. (XML columns fail with an NPE in `TypeBuilder` on all three, since XML isn't supported yet — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
